### PR TITLE
Make all entities serializable.

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -1,8 +1,8 @@
 use super::{Emoji, Field, Source};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Account {
     pub id: String,
     pub username: String,

--- a/src/entities/activity.rs
+++ b/src/entities/activity.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Activity {
     pub week: String,
     pub statuses: String,

--- a/src/entities/application.rs
+++ b/src/entities/application.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Application {
     pub name: String,
     pub website: Option<String>,

--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -1,10 +1,10 @@
 use core::fmt;
-use serde::{de, ser, Deserialize};
+use serde::{de, ser, Deserialize, Serialize};
 use std::str::FromStr;
 
 use crate::error::Error;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Attachment {
     pub id: String,
     pub r#type: AttachmentType,
@@ -17,7 +17,7 @@ pub struct Attachment {
     pub blurhash: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AttachmentMeta {
     pub original: Option<MetaSub>,
     pub small: Option<MetaSub>,
@@ -34,7 +34,7 @@ pub struct AttachmentMeta {
     pub audio_channel: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MetaSub {
     // For Image, Gifv, Video
     pub width: Option<u32>,
@@ -50,7 +50,7 @@ pub struct MetaSub {
     pub bitrate: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Focus {
     pub x: f64,
     pub y: f64,
@@ -100,7 +100,7 @@ impl ser::Serialize for AttachmentType {
     }
 }
 
-impl<'de> de::Deserialize<'de> for AttachmentType {
+impl<'de> Deserialize<'de> for AttachmentType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/src/entities/card.rs
+++ b/src/entities/card.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Card {
     pub url: String,
     pub title: String,
@@ -14,7 +16,7 @@ pub struct Card {
     pub height: Option<u32>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum CardType {
     Link,
     Photo,

--- a/src/entities/context.rs
+++ b/src/entities/context.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::Status;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Context {
     pub ancestors: Vec<Status>,
     pub descendants: Vec<Status>,

--- a/src/entities/conversation.rs
+++ b/src/entities/conversation.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::{Account, Status};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Conversation {
     pub id: String,
     pub accounts: Vec<Account>,

--- a/src/entities/emoji.rs
+++ b/src/entities/emoji.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Emoji {
     pub shortcode: String,
     pub static_url: String,

--- a/src/entities/featured_tag.rs
+++ b/src/entities/featured_tag.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeaturedTag {
     pub id: String,
     pub name: String,

--- a/src/entities/field.rs
+++ b/src/entities/field.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Field {
     pub name: String,
     pub value: String,

--- a/src/entities/filter.rs
+++ b/src/entities/filter.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Filter {
     pub id: String,
     pub phrase: String,
@@ -11,7 +11,7 @@ pub struct Filter {
     pub whole_word: bool,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum FilterContext {
     Home,
     Notifications,

--- a/src/entities/history.rs
+++ b/src/entities/history.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct History {
     pub day: u64,
     pub uses: usize,

--- a/src/entities/identity_proof.rs
+++ b/src/entities/identity_proof.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct IdentityProof {
     pub provider: String,
     pub provider_username: String,

--- a/src/entities/instance.rs
+++ b/src/entities/instance.rs
@@ -1,7 +1,7 @@
 use super::{Account, Stats, URLs};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Instance {
     pub uri: String,
     pub title: String,
@@ -18,21 +18,21 @@ pub struct Instance {
     pub configuration: Option<InstanceConfig>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct InstanceConfig {
     pub statuses: Statuses,
     pub media_attachments: MediaAttachments,
     pub polls: Polls,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Statuses {
     pub max_characters: u32,
     pub max_media_attachments: u32,
     pub characters_reserved_per_url: u32,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MediaAttachments {
     pub supported_mime_types: Vec<String>,
     pub image_size_limit: u32,
@@ -42,7 +42,7 @@ pub struct MediaAttachments {
     pub video_matrix_limit: u32,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Polls {
     pub max_options: u32,
     pub max_characters_per_option: u32,

--- a/src/entities/list.rs
+++ b/src/entities/list.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct List {
     pub id: String,
     pub title: String,

--- a/src/entities/marker.rs
+++ b/src/entities/marker.rs
@@ -1,12 +1,13 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Marker {
     pub home: InnerMarker,
     pub notifications: InnerMarker,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct InnerMarker {
     pub last_read_id: String,
     pub version: u32,

--- a/src/entities/mention.rs
+++ b/src/entities/mention.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Mention {
     pub id: String,
     pub username: String,

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -2,10 +2,10 @@ use super::{Account, Status};
 use crate::error::{Error, Kind};
 use chrono::{DateTime, Utc};
 use core::str::FromStr;
-use serde::{de, ser};
+use serde::{de, Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Notification {
     pub account: Account,
     pub created_at: DateTime<Utc>,
@@ -62,7 +62,7 @@ impl FromStr for NotificationType {
     }
 }
 
-impl ser::Serialize for NotificationType {
+impl Serialize for NotificationType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -71,7 +71,7 @@ impl ser::Serialize for NotificationType {
     }
 }
 
-impl<'de> de::Deserialize<'de> for NotificationType {
+impl<'de> Deserialize<'de> for NotificationType {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,

--- a/src/entities/poll.rs
+++ b/src/entities/poll.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use super::{Emoji, PollOption};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Poll {
     pub id: String,
     pub expires_at: Option<DateTime<Utc>>,

--- a/src/entities/poll_option.rs
+++ b/src/entities/poll_option.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PollOption {
     pub title: String,
     pub votes_count: Option<u32>,

--- a/src/entities/preferences.rs
+++ b/src/entities/preferences.rs
@@ -1,11 +1,11 @@
 use core::fmt;
-use serde::{de, ser};
+use serde::{de, Deserialize, Serialize};
 use std::str::FromStr;
 
 use super::StatusVisibility;
 use crate::error::{Error, Kind};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Preferences {
     pub posting_default_visibility: StatusVisibility,
     pub posting_default_sensitive: bool,
@@ -44,7 +44,7 @@ impl FromStr for ExpandMedia {
     }
 }
 
-impl ser::Serialize for ExpandMedia {
+impl Serialize for ExpandMedia {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/src/entities/push_subscription.rs
+++ b/src/entities/push_subscription.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PushSubscription {
     pub id: String,
     pub endpoint: String,
@@ -6,7 +8,7 @@ pub struct PushSubscription {
     pub alerts: Alerts,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Alerts {
     pub follow: bool,
     pub favourite: bool,

--- a/src/entities/reaction.rs
+++ b/src/entities/reaction.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::Account;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Reaction {
     pub count: u32,
     pub me: bool,

--- a/src/entities/relationship.rs
+++ b/src/entities/relationship.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Relationship {
     pub id: String,
     pub following: bool,

--- a/src/entities/report.rs
+++ b/src/entities/report.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Report {
     pub id: String,
     pub action_taken: String,

--- a/src/entities/results.rs
+++ b/src/entities/results.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::{Account, Status, Tag};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Results {
     pub accounts: Vec<Account>,
     pub statuses: Vec<Status>,

--- a/src/entities/scheduled_status.rs
+++ b/src/entities/scheduled_status.rs
@@ -1,7 +1,8 @@
 use super::{Attachment, StatusParams};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ScheduledStatus {
     pub id: String,
     pub scheduled_at: DateTime<Utc>,

--- a/src/entities/source.rs
+++ b/src/entities/source.rs
@@ -1,7 +1,7 @@
 use super::Field;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Source {
     pub privacy: Option<String>,
     pub sensitive: Option<bool>,

--- a/src/entities/stats.rs
+++ b/src/entities/stats.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Stats {
     pub user_count: u32,
     pub status_count: u64,

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -1,10 +1,12 @@
+use serde::{Deserialize, Serialize};
+
 use super::{Account, Application, Attachment, Card, Emoji, Mention, Poll, Reaction, Tag};
 use crate::error::{Error, Kind};
 use chrono::{DateTime, Utc};
 use core::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Status {
     pub id: String,
     pub uri: String,
@@ -39,7 +41,7 @@ pub struct Status {
     pub bookmarked: Option<bool>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum StatusVisibility {
     Public,
     Unlisted,

--- a/src/entities/status_params.rs
+++ b/src/entities/status_params.rs
@@ -1,7 +1,8 @@
 use super::StatusVisibility;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StatusParams {
     pub text: String,
     pub in_reply_to_id: Option<String>,

--- a/src/entities/tag.rs
+++ b/src/entities/tag.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::History;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Tag {
     pub name: String,
     pub url: String,

--- a/src/entities/token.rs
+++ b/src/entities/token.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Token {
     pub access_token: String,
     pub token_type: String,

--- a/src/entities/urls.rs
+++ b/src/entities/urls.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct URLs {
     pub streaming_api: String,
 }


### PR DESCRIPTION
You seem to have a solid entity model in place, and I'd like to serialize it to a cache. This PR makes everything in the `entities` module derive both `Deserialize` and `Serialize`.