### PR TITLE
Replace manual error impls with thiserror derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tungstenite = { version = "0.17", features = ["native-tls"] }
 urlencoding = { version = "2.1" }
 log = "0.4"
 env_logger = "0.8"
+thiserror = "1"


### PR DESCRIPTION
Hi!

I found that you implement all the error stuff yourself. This can be done in a more simple way by deriving the `thiserror::Error` trait.

Enjoy! :wink: 