### PR TITLE
Make env_logger dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,7 @@ hex = { version = "0.4" }
 tungstenite = { version = "0.17", features = ["native-tls"] }
 urlencoding = { version = "2.1" }
 log = "0.4"
-env_logger = "0.8"
 thiserror = "1"
+
+[dev-dependencies]
+env_logger = "0.8"


### PR DESCRIPTION
There's no need to have env_logger in normal dependencies if it is only used in the examples.

This will conflict with #31, I will rebase as needed, of course!