### PR TITLE
Fix pleroma marker entity

### DIFF
--- a/examples/mastodon_marker.rs
+++ b/examples/mastodon_marker.rs
@@ -1,0 +1,37 @@
+use std::env;
+
+use megalodon::{entities, error, generator};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    match env::var("MASTODON_ACCESS_TOKEN") {
+        Ok(token) => {
+            let res = get_markers("https://fedibird.com", token).await;
+            match res {
+                Ok(res) => {
+                    println!("{:#?}", res);
+                }
+                Err(err) => {
+                    println!("{:#?}", err);
+                }
+            }
+        }
+        Err(err) => {
+            println!("{:#?}", err)
+        }
+    }
+}
+
+async fn get_markers(url: &str, access_token: String) -> Result<entities::Marker, error::Error> {
+    let client = generator(
+        megalodon::SNS::Mastodon,
+        url.to_string(),
+        Some(access_token),
+        None,
+    );
+    let res = client
+        .get_markers(vec![String::from("home"), String::from("notifications")])
+        .await?;
+    Ok(res.json())
+}

--- a/examples/pleroma_marker.rs
+++ b/examples/pleroma_marker.rs
@@ -1,0 +1,37 @@
+use std::env;
+
+use megalodon::{entities, error, generator};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    match env::var("PLEROMA_ACCESS_TOKEN") {
+        Ok(token) => {
+            let res = get_markers("https://pleroma.io", token).await;
+            match res {
+                Ok(res) => {
+                    println!("{:#?}", res);
+                }
+                Err(err) => {
+                    println!("{:#?}", err);
+                }
+            }
+        }
+        Err(err) => {
+            println!("{:#?}", err)
+        }
+    }
+}
+
+async fn get_markers(url: &str, access_token: String) -> Result<entities::Marker, error::Error> {
+    let client = generator(
+        megalodon::SNS::Pleroma,
+        url.to_string(),
+        Some(access_token),
+        None,
+    );
+    let res = client
+        .get_markers(vec![String::from("notifications")])
+        .await?;
+    Ok(res.json())
+}

--- a/src/entities/marker.rs
+++ b/src/entities/marker.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Marker {
-    pub home: InnerMarker,
-    pub notifications: InnerMarker,
+    pub home: Option<InnerMarker>,
+    pub notifications: Option<InnerMarker>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -12,4 +12,5 @@ pub struct InnerMarker {
     pub last_read_id: String,
     pub version: u32,
     pub updated_at: DateTime<Utc>,
+    pub unread_count: Option<u32>,
 }

--- a/src/mastodon/entities/marker.rs
+++ b/src/mastodon/entities/marker.rs
@@ -18,8 +18,8 @@ struct InnerMarker {
 impl Into<MegalodonEntities::Marker> for Marker {
     fn into(self) -> MegalodonEntities::Marker {
         MegalodonEntities::Marker {
-            home: self.home.into(),
-            notifications: self.notifications.into(),
+            home: Some(self.home.into()),
+            notifications: Some(self.notifications.into()),
         }
     }
 }
@@ -30,6 +30,7 @@ impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
             last_read_id: self.last_read_id,
             version: self.version,
             updated_at: self.updated_at,
+            unread_count: None,
         }
     }
 }

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -2273,10 +2273,11 @@ impl megalodon::Megalodon for Mastodon {
         &self,
         timeline: Vec<String>,
     ) -> Result<Response<MegalodonEntities::Marker>, Error> {
-        let params = Vec::<String>::from([format!(
-            "timeline={}",
-            serde_json::to_string(&timeline).unwrap()
-        )]);
+        let params: Vec<String> = timeline
+            .into_iter()
+            .map(|t| format!("timeline[]={}", t))
+            .collect();
+
         let mut path = "/api/v1/markers".to_string();
         if params.len() > 0 {
             path = path + "?" + params.join("&").as_str();

--- a/src/pleroma/entities/marker.rs
+++ b/src/pleroma/entities/marker.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Marker {
-    home: InnerMarker,
     notifications: InnerMarker,
 }
 
@@ -12,14 +11,21 @@ pub struct Marker {
 struct InnerMarker {
     last_read_id: String,
     version: u32,
+    #[serde(with = "date_format_without_tz")]
     updated_at: DateTime<Utc>,
+    pleroma: PleromaMarker,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct PleromaMarker {
+    unread_count: u32,
 }
 
 impl Into<MegalodonEntities::Marker> for Marker {
     fn into(self) -> MegalodonEntities::Marker {
         MegalodonEntities::Marker {
-            home: self.home.into(),
-            notifications: self.notifications.into(),
+            home: None,
+            notifications: Some(self.notifications.into()),
         }
     }
 }
@@ -30,6 +36,31 @@ impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
             last_read_id: self.last_read_id,
             version: self.version,
             updated_at: self.updated_at,
+            unread_count: Some(self.pleroma.unread_count),
         }
+    }
+}
+
+mod date_format_without_tz {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    const FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S";
+
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}", date.format(FORMAT));
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Utc.datetime_from_str(&s, FORMAT)
+            .map_err(serde::de::Error::custom)
     }
 }

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -2267,10 +2267,11 @@ impl megalodon::Megalodon for Pleroma {
         &self,
         timeline: Vec<String>,
     ) -> Result<Response<MegalodonEntities::Marker>, Error> {
-        let params = Vec::<String>::from([format!(
-            "timeline={}",
-            serde_json::to_string(&timeline).unwrap()
-        )]);
+        let params: Vec<String> = timeline
+            .into_iter()
+            .map(|t| format!("timeline[]={}", t))
+            .collect();
+
         let mut path = "/api/v1/markers".to_string();
         if params.len() > 0 {
             path = path + "?" + params.join("&").as_str();


### PR DESCRIPTION
1. Pleroma marker does not have `home` marker, it has only `notifications` marker.
2. Pleroma marker's timestamp does not contain the timezone, so it was the wrong format as DateTime. For example: `2020-04-07T13:49:36`
