### PR TITLE
refs #52 Fix using json request in patch, put and delete request in M…

### DIFF
--- a/examples/mastodon_update_credentials.rs
+++ b/examples/mastodon_update_credentials.rs
@@ -1,0 +1,33 @@
+use megalodon::{generator, SNS};
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let Ok(url) = env::var("MASTODON_URL") else {
+        println!("Specify MASTODON_URL!!");
+        return
+    };
+    let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
+        println!("Specify MASTODON_ACCESS_TOKEN!!");
+        return
+    };
+
+    let client = generator(SNS::Mastodon, url, Some(token), None);
+
+    let update_creds = megalodon::megalodon::UpdateCredentialsInputOptions {
+        fields_attributes: Some(vec![megalodon::megalodon::CredentialsFieldAttribute {
+            name: "Test".to_string(),
+            value: "test".to_string(),
+        }]),
+        ..Default::default()
+    };
+
+    let res = client
+        .update_credentials(Some(&update_creds))
+        .await
+        .unwrap();
+
+    println!("{:#?}", res.json())
+}

--- a/src/mastodon/api_client.rs
+++ b/src/mastodon/api_client.rs
@@ -208,7 +208,7 @@ impl APIClient {
             req = req.headers(headers);
         }
 
-        let res = req.form(params).send().await?;
+        let res = req.json(params).send().await?;
         let status = res.status();
         match status {
             reqwest::StatusCode::OK
@@ -308,7 +308,7 @@ impl APIClient {
             req = req.headers(headers);
         }
 
-        let res = req.form(params).send().await?;
+        let res = req.json(params).send().await?;
         let status = res.status();
         match status {
             reqwest::StatusCode::OK
@@ -358,7 +358,7 @@ impl APIClient {
             req = req.headers(headers);
         }
 
-        let res = req.form(params).send().await?;
+        let res = req.json(params).send().await?;
         let status = res.status();
         match status {
             reqwest::StatusCode::OK


### PR DESCRIPTION
…astodon

fixes #52 

In https://github.com/h3poteto/megalodon-rs/pull/41
we fixed array serialization. At the same time, we started to use `json` method instead of `form` in post request.
However, we need to change patch, put, and delete methods too.