### PR TITLE
fix(mastodon): fields_attributes as hash instead of array

### DIFF
--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -294,8 +294,14 @@ impl megalodon::Megalodon for Mastodon {
                 }
             }
             if let Some(fields_attributes) = &options.fields_attributes {
-                if let Some(json_fields_attributes) = serde_json::to_value(&fields_attributes).ok()
-                {
+                let json_fields_attributes = serde_json::map::Map::from_iter(
+                    fields_attributes
+                        .iter()
+                        .enumerate()
+                        .map(|(x, y)| (x.to_string(), serde_json::to_value(y).ok().into())),
+                );
+
+                if let Ok(json_fields_attributes) = serde_json::to_value(json_fields_attributes) {
                     params.insert("fields_attributes", json_fields_attributes);
                 }
             }


### PR DESCRIPTION
This fixes the `fields_attributes` being incorrectly referred to as Array instead of an Object (see [documentation](https://docs.joinmastodon.org/methods/accounts/#update_credentials)).

As this « Object » is supposed to be an ordered hash of some sorts, this makes sense to consider it as a Vector when calling the function `update_credentials` and transform it in said hash afterwards.