### PR TITLE
Auto-reconnect WebSocket with tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ url = "2.2.2"
 oauth2 = { version = "4.2" }
 sha1 = { version = "0.10" }
 hex = { version = "0.4" }
-tungstenite = { version = "0.18", features = ["native-tls"] }
+tokio-tungstenite = { version ="0.18", features = ["native-tls"] }
 urlencoding = { version = "2.1" }
 log = "0.4"
 thiserror = "1"
+futures-util = "0.3"
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/examples/mastodon_streaming.rs
+++ b/examples/mastodon_streaming.rs
@@ -23,7 +23,7 @@ fn streaming(url: &str, access_token: String) {
         Some(access_token),
         None,
     );
-    let streaming = client.public_streaming(url.to_string());
+    let streaming = client.user_streaming(url.to_string());
 
     streaming.listen(Box::new(|message| match message {
         Message::Update(mes) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     /// WebSocketError from [`tungstenite::error::Error`].
     /// This error will be raised when tungstenite WebSocket raises an error.
     #[error(transparent)]
-    WebSocketError(#[from] tungstenite::error::Error),
+    WebSocketError(#[from] tokio_tungstenite::tungstenite::error::Error),
     /// JsonError from [`serde_json::Error`].
     /// This error will be raised when failed to parse some json.
     #[error(transparent)]


### PR DESCRIPTION
Rewrite with `tokio-tungstenite` and `tokio::time::timeout` for reading messages.