### PR TITLE
make `following` optional

### DIFF
--- a/src/entities/tag.rs
+++ b/src/entities/tag.rs
@@ -7,6 +7,5 @@ pub struct Tag {
     pub name: String,
     pub url: String,
     pub history: Option<Vec<History>>,
-    #[serde(default)]
-    pub following: bool,
+    pub following: Option<bool>,
 }

--- a/src/entities/tag.rs
+++ b/src/entities/tag.rs
@@ -7,5 +7,6 @@ pub struct Tag {
     pub name: String,
     pub url: String,
     pub history: Option<Vec<History>>,
+    #[serde(default)]
     pub following: bool,
 }

--- a/src/mastodon/entities/tag.rs
+++ b/src/mastodon/entities/tag.rs
@@ -7,8 +7,7 @@ pub struct Tag {
     name: String,
     url: String,
     history: Option<Vec<History>>,
-    #[serde(default)]
-    following: bool,
+    following: Option<bool>,
 }
 
 impl Into<MegalodonEntities::Tag> for Tag {

--- a/src/mastodon/entities/tag.rs
+++ b/src/mastodon/entities/tag.rs
@@ -7,6 +7,7 @@ pub struct Tag {
     name: String,
     url: String,
     history: Option<Vec<History>>,
+    #[serde(default)]
     following: bool,
 }
 

--- a/src/pleroma/entities/tag.rs
+++ b/src/pleroma/entities/tag.rs
@@ -7,8 +7,7 @@ pub struct Tag {
     name: String,
     url: String,
     history: Option<Vec<History>>,
-    #[serde(default)]
-    following: bool,
+    following: Option<bool>,
 }
 
 impl Into<MegalodonEntities::Tag> for Tag {

--- a/src/pleroma/entities/tag.rs
+++ b/src/pleroma/entities/tag.rs
@@ -7,6 +7,7 @@ pub struct Tag {
     name: String,
     url: String,
     history: Option<Vec<History>>,
+    #[serde(default)]
     following: bool,
 }
 


### PR DESCRIPTION
I got the following error whenever I tried to retrieve the home timeline from the `mastodon.social` instance:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("missing field `following`", line: 1, column: 23826)', src/response.rs:39:56
```

I had a look at the json that was returned, and the `following` property wasn't there. And indeed, it is listed as `optional` [here](https://docs.joinmastodon.org/entities/Tag/#following). I've made the property optional on the related entities.