### PR TITLE
add support for the user authorization flow

### DIFF
--- a/examples/mastodon_user_auth.rs
+++ b/examples/mastodon_user_auth.rs
@@ -1,0 +1,72 @@
+use megalodon::generator;
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let Ok(url) = env::var("MASTODON_URL") else {
+        println!("Specify MASTODON_URL!!");
+        return
+    };
+    let Ok(client_id) = env::var("MASTODON_CLIENT_ID") else {
+        println!("Specify MASTODON_CLIENT_ID");
+        return
+    };
+    let Ok(client_secret) = env::var("MASTODON_CLIENT_SECRET") else {
+        println!("Specify MASTODON_CLIENT_SECRET");
+        return
+    };
+    let Ok(redirect) = env::var("MASTODON_REDIRECT_URL") else {
+        println!("Specify MASTODON_REDIRECT_URL");
+        return
+    };
+    let client = generator(megalodon::SNS::Mastodon, url, None, None);
+
+    let scopes = "read read:accounts read:bookmarks read:favourites read:statuses write write:bookmarks write:favourites write:media write:statuses follow".split(" ")
+    .map(|e| e.to_string())
+    .collect();
+
+    match client
+        .authorize_user_code_url(
+            client_id.clone(),
+            client_secret.clone(),
+            scopes,
+            redirect.clone(),
+        )
+        .await
+    {
+        Ok(url) => {
+            println!("Authorization URL is generated");
+            println!("{url}");
+
+            println!("Enter authorization code from website: ");
+
+            let mut code = String::new();
+            std::io::stdin().read_line(&mut code).ok();
+
+            match client
+                .fetch_access_token(
+                    client_id,
+                    client_secret,
+                    code.trim().to_string(),
+                    megalodon::default::NO_REDIRECT.to_string(),
+                )
+                .await
+            {
+                Ok(token_data) => {
+                    println!("access_token: {}", token_data.access_token);
+                    if let Some(refresh) = token_data.refresh_token {
+                        println!("refresh_token: {}", refresh);
+                    }
+                }
+                Err(err) => {
+                    println!("{:#?}", err);
+                }
+            }
+        }
+        Err(err) => {
+            println!("{:#?}", err);
+        }
+    }
+}

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -74,6 +74,24 @@ impl Mastodon {
 
 #[async_trait]
 impl megalodon::Megalodon for Mastodon {
+    async fn authorize_user_code_url(
+        &self,
+        client_id: String,
+        client_secret: String,
+        scopes: Vec<String>,
+        redirect_uri: String,
+    ) -> Result<String, Error> {
+        let url = self
+            .generate_auth_url(
+                client_id.clone(),
+                client_secret.clone(),
+                scopes.iter().map(String::as_str).collect(),
+                redirect_uri.clone(),
+            )
+            .await?;
+        Ok(url)
+    }
+
     async fn register_app(
         &self,
         client_name: String,

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -31,6 +31,15 @@ pub trait Megalodon {
     // ======================================
     // apps/oauth
     // ======================================
+    /// Generate a code URL to authorize a user to a application
+    async fn authorize_user_code_url(
+        &self,
+        client_id: String,
+        client_secret: String,
+        scopes: Vec<String>,
+        redirect_uri: String,
+    ) -> Result<String, Error>;
+
     /// Fetch OAuth access token.
     /// Get an access token based client_id, client_secret and authorization_code.
     async fn fetch_access_token(

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -71,6 +71,24 @@ impl Pleroma {
 
 #[async_trait]
 impl megalodon::Megalodon for Pleroma {
+    async fn authorize_user_code_url(
+        &self,
+        client_id: String,
+        client_secret: String,
+        scopes: Vec<String>,
+        redirect_uri: String,
+    ) -> Result<String, Error> {
+        let url = self
+            .generate_auth_url(
+                client_id.clone(),
+                client_secret.clone(),
+                scopes.iter().map(String::as_str).collect(),
+                redirect_uri.clone(),
+            )
+            .await?;
+        Ok(url)
+    }
+
     async fn register_app(
         &self,
         client_name: String,


### PR DESCRIPTION
I'm working on a Mastodon Desktop app. [The flow](https://docs.joinmastodon.org/client/authorized/#login) requires authorising a user with client id / secret in order to retrieve a URL that the user can visit. Then, in the next step, the user copy pastes the code and retrieves the access token. This was not possible because the code URL was only generated when registering & creating an app. But I already have an app and I want to use this library to allow users to authenticate in the already-registered app.

This PR adds support for that. I've also add a working example.