### PR TITLE
Fix poll events for pleroma and mastodon

### DIFF
--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -92,7 +92,9 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             NotificationType::Favourite => {
                 MegalodonEntities::notification::NotificationType::Favourite
             }
-            NotificationType::Poll => MegalodonEntities::notification::NotificationType::PollVote,
+            NotificationType::Poll => {
+                MegalodonEntities::notification::NotificationType::PollExpired
+            }
             NotificationType::Status => MegalodonEntities::notification::NotificationType::Status,
         }
     }

--- a/src/pleroma/entities/notification.rs
+++ b/src/pleroma/entities/notification.rs
@@ -93,7 +93,9 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             NotificationType::Favourite => {
                 MegalodonEntities::notification::NotificationType::Favourite
             }
-            NotificationType::Poll => MegalodonEntities::notification::NotificationType::PollVote,
+            NotificationType::Poll => {
+                MegalodonEntities::notification::NotificationType::PollExpired
+            }
             NotificationType::PleromaEmojiReaction => {
                 MegalodonEntities::notification::NotificationType::EmojiReaction
             }


### PR DESCRIPTION
Mastodon and Pleroma don't send poll vote events.
It only send poll expired events.