### PR TITLE
Add parse_from_string for deserializing mastodon history entities

### DIFF
--- a/src/entities/history.rs
+++ b/src/entities/history.rs
@@ -6,3 +6,14 @@ pub struct History {
     pub uses: usize,
     pub accounts: usize,
 }
+
+pub fn parse_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        T: std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    Ok(String::deserialize(deserializer)?
+        .parse()
+        .map_err(serde::de::Error::custom)?)
+}

--- a/src/mastodon/entities/history.rs
+++ b/src/mastodon/entities/history.rs
@@ -3,8 +3,11 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct History {
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     day: u64,
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     uses: usize,
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     accounts: usize,
 }
 

--- a/src/pleroma/entities/history.rs
+++ b/src/pleroma/entities/history.rs
@@ -3,8 +3,11 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct History {
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     day: u64,
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     uses: usize,
+    #[serde(deserialize_with = "MegalodonEntities::history::parse_from_string")]
     accounts: usize,
 }
 


### PR DESCRIPTION
This pull request adds a new function to parse string values to u64, usize and possibly other types and uses it to deserialize field values in the history mastodon entity.