### PR TITLE
Fix typo in token endpoint URL passed to BasicClient

### DIFF
--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -56,7 +56,7 @@ impl Mastodon {
             Some(ClientSecret::new(client_secret)),
             AuthUrl::new(format!("{}{}", self.base_url, "/oauth/authorize").to_string())?,
             Some(TokenUrl::new(
-                format!("{}{}", self.base_url, "/oaut/token").to_string(),
+                format!("{}{}", self.base_url, "/oauth/token").to_string(),
             )?),
         )
         .set_redirect_uri(RedirectUrl::new(redirect_uri)?);

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -53,7 +53,7 @@ impl Pleroma {
             Some(ClientSecret::new(client_secret)),
             AuthUrl::new(format!("{}{}", self.base_url, "/oauth/authorize").to_string())?,
             Some(TokenUrl::new(
-                format!("{}{}", self.base_url, "/oaut/token").to_string(),
+                format!("{}{}", self.base_url, "/oauth/token").to_string(),
             )?),
         )
         .set_redirect_uri(RedirectUrl::new(redirect_uri)?);


### PR DESCRIPTION
I'm not sure if these are used for anything, but they're definitely spelled wrong.