### PR TITLE
Add notification update

### DIFF
--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -27,6 +27,7 @@ pub enum NotificationType {
     PollExpired,
     Status,
     EmojiReaction,
+    Update,
 }
 
 impl fmt::Display for NotificationType {
@@ -41,6 +42,7 @@ impl fmt::Display for NotificationType {
             NotificationType::FollowRequest => write!(f, "follow_request"),
             NotificationType::Status => write!(f, "status"),
             NotificationType::EmojiReaction => write!(f, "emoji_reaction"),
+            NotificationType::Update => write!(f, "update"),
         }
     }
 }
@@ -58,6 +60,7 @@ impl FromStr for NotificationType {
             "follow_request" => Ok(NotificationType::FollowRequest),
             "status" => Ok(NotificationType::Status),
             "emoji_reaction" => Ok(NotificationType::EmojiReaction),
+            "update" => Ok(NotificationType::Update),
             _ => Err(Error::new_own(s.to_owned(), Kind::ParseError, None, None)),
         }
     }

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -22,6 +22,7 @@ pub enum NotificationType {
     Favourite,
     Poll,
     Status,
+    Update,
 }
 
 impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
@@ -40,6 +41,7 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
                 MegalodonEntities::notification::NotificationType::PollExpired
             }
             NotificationType::Status => MegalodonEntities::notification::NotificationType::Status,
+            NotificationType::Update => MegalodonEntities::notification::NotificationType::Update,
         }
     }
 }

--- a/src/pleroma/entities/notification.rs
+++ b/src/pleroma/entities/notification.rs
@@ -26,6 +26,7 @@ pub enum NotificationType {
     Favourite,
     Poll,
     PleromaEmojiReaction,
+    Update,
 }
 
 impl fmt::Display for NotificationType {
@@ -38,6 +39,7 @@ impl fmt::Display for NotificationType {
             NotificationType::PleromaEmojiReaction => write!(f, "pleroma:emoji_reaction"),
             NotificationType::Poll => write!(f, "poll"),
             NotificationType::FollowRequest => write!(f, "follow_request"),
+            NotificationType::Update => write!(f, "update"),
         }
     }
 }
@@ -54,6 +56,7 @@ impl FromStr for NotificationType {
             "pleroma:emoji_reaction" => Ok(NotificationType::PleromaEmojiReaction),
             "poll" => Ok(NotificationType::Poll),
             "follow_request" => Ok(NotificationType::FollowRequest),
+            "update" => Ok(NotificationType::Update),
             _ => Err(Error::new_own(s.to_owned(), Kind::ParseError, None, None)),
         }
     }
@@ -99,6 +102,7 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             NotificationType::PleromaEmojiReaction => {
                 MegalodonEntities::notification::NotificationType::EmojiReaction
             }
+            NotificationType::Update => MegalodonEntities::notification::NotificationType::Update,
         }
     }
 }


### PR DESCRIPTION
This adds the `update` `enum` which I've been getting in notifications. It also adds `characters_reserved_per_url` back. I've modelled this as optional as it doesn't exist in Pleroma.