### PR TITLE
Use nodeinfo to detect SNS

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1,0 +1,148 @@
+use serde::Deserialize;
+
+use crate::{error, SNS};
+
+#[derive(Deserialize, Debug)]
+struct Links {
+    links: Vec<Link>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Link {
+    href: String,
+    rel: String,
+}
+
+const NODEINFO_20: &str = "http://nodeinfo.diaspora.software/ns/schema/2.0";
+const NODEINFO_21: &str = "http://nodeinfo.diaspora.software/ns/schema/2.1";
+
+#[derive(Deserialize, Debug)]
+struct Nodeinfo20 {
+    software: Software,
+    metadata: Metadata,
+}
+
+#[derive(Deserialize, Debug)]
+struct Nodeinfo21 {
+    software: Software,
+    metadata: Metadata,
+}
+
+#[derive(Deserialize, Debug)]
+struct Software {
+    name: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Metadata {
+    upstream: Option<Upstream>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Upstream {
+    name: String,
+}
+
+/// Detect which SNS the provided URL is. To detect SNS, the URL has to open `/api/v1/instance` or `/api/meta` endpoint.
+pub async fn detector(url: &str) -> Result<SNS, error::Error> {
+    let client = reqwest::Client::builder().user_agent("megalodon").build()?;
+    let links = client
+        .get(format!("{}{}", url, "/.well-known/nodeinfo"))
+        .send()
+        .await?
+        .json::<Links>()
+        .await?;
+    let Some(link) = links.links
+        .iter()
+        .find(|l| l.rel == NODEINFO_20 || l.rel == NODEINFO_21) else {
+            return Err(error::Error::new_own(String::from("Could not find nodeinfo"), error::Kind::NodeinfoError, None, None));
+        };
+
+    match link.rel.as_str() {
+        NODEINFO_20 => {
+            let nodeinfo = client
+                .get(link.href.as_str())
+                .send()
+                .await?
+                .json::<Nodeinfo20>()
+                .await?;
+            match nodeinfo.software.name.as_str() {
+                "pleroma" => Ok(SNS::Pleroma),
+                "mastodon" => Ok(SNS::Mastodon),
+                _ => {
+                    if let Some(upstream) = nodeinfo.metadata.upstream {
+                        if upstream.name == "mastodon" {
+                            return Ok(SNS::Mastodon);
+                        }
+                    }
+                    Err(error::Error::new_own(
+                        String::from("Unknown SNS"),
+                        error::Kind::UnknownSNSError,
+                        Some(url.to_string()),
+                        None,
+                    ))
+                }
+            }
+        }
+        NODEINFO_21 => {
+            let nodeinfo = client
+                .get(link.href.as_str())
+                .send()
+                .await?
+                .json::<Nodeinfo21>()
+                .await?;
+            match nodeinfo.software.name.as_str() {
+                "pleroma" => Ok(SNS::Pleroma),
+                "mastodon" => Ok(SNS::Mastodon),
+                _ => {
+                    if let Some(upstream) = nodeinfo.metadata.upstream {
+                        if upstream.name == "mastodon" {
+                            return Ok(SNS::Mastodon);
+                        }
+                    }
+                    Err(error::Error::new_own(
+                        String::from("Unknown SNS"),
+                        error::Kind::UnknownSNSError,
+                        Some(url.to_string()),
+                        None,
+                    ))
+                }
+            }
+        }
+        _ => Err(error::Error::new_own(
+            String::from("Cound not find nodeinfo"),
+            error::Kind::NodeinfoError,
+            Some(url.to_string()),
+            None,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_detector_mastodon() {
+        let sns = detector("https://mastodon.social").await;
+
+        assert!(sns.is_ok());
+        assert_eq!(sns.unwrap(), SNS::Mastodon);
+    }
+
+    #[tokio::test]
+    async fn test_detector_pleroma() {
+        let sns = detector("https://pleroma.io").await;
+
+        assert!(sns.is_ok());
+        assert_eq!(sns.unwrap(), SNS::Pleroma);
+    }
+
+    #[tokio::test]
+    async fn test_detector_fedibird() {
+        let sns = detector("https://fedibird.com").await;
+
+        assert!(sns.is_ok());
+        assert_eq!(sns.unwrap(), SNS::Mastodon);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,12 @@ pub enum Kind {
     /// The request is not completed error.
     #[error("partial content error")]
     HTTPPartialContentError,
+    /// Failed to find nodeinfo.
+    #[error("nodeinfo error")]
+    NodeinfoError,
+    /// The SNS is unknown.
+    #[error("unknown sns")]
+    UnknownSNSError,
 }
 
 impl Error {


### PR DESCRIPTION
All ActivityPub services have `/.well-known/nodeinfo` endpoint and the endpoint also provides an SNS type. So it is better to use this endpoint to detect SNS.