### PR TITLE
Add upload_media_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 thiserror = "1"
 futures-util = "0.3"
 http =  "0.2"
+uuid = { version = "1.3.4", features = ["v4"] }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/entities/history.rs
+++ b/src/entities/history.rs
@@ -8,10 +8,10 @@ pub struct History {
 }
 
 pub fn parse_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-        T: std::str::FromStr,
-        <T as std::str::FromStr>::Err: std::fmt::Display,
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
 {
     Ok(String::deserialize(deserializer)?
         .parse()

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -19,7 +19,9 @@ use serde_json::Value;
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use tokio::fs::File;
+use tokio::io::AsyncRead;
 use tokio_util::codec::{BytesCodec, FramedRead};
+use uuid::Uuid;
 
 /// Friendica API Client which satisfies megalodon trait.
 #[derive(Debug, Clone)]
@@ -64,6 +66,42 @@ impl Friendica {
             .set_response_type(&ResponseType::new("code".to_string()))
             .url();
         Ok(auth_url.to_string())
+    }
+
+    async fn _upload_media<T>(
+        &self,
+        file_name: String,
+        reader: T,
+        options: Option<&megalodon::UploadMediaInputOptions>,
+    ) -> Result<Response<MegalodonEntities::UploadMedia>, Error>
+    where
+        T: AsyncRead + Send + Sync + 'static,
+    {
+        let stream = FramedRead::new(reader, BytesCodec::new());
+        let file_body = reqwest::Body::wrap_stream(stream);
+        let part = reqwest::multipart::Part::stream(file_body).file_name(file_name);
+
+        let mut form = reqwest::multipart::Form::new().part("file", part);
+        if let Some(options) = options {
+            if let Some(description) = &options.description {
+                form = form.text("description", description.clone());
+            }
+            if let Some(focus) = &options.focus {
+                form = form.text("focus", focus.clone());
+            }
+        }
+
+        let res = self
+            .client
+            .post_multipart::<entities::Attachment>("/api/v2/media", form, None)
+            .await?;
+
+        Ok(Response::<MegalodonEntities::UploadMedia>::new(
+            res.json.into(),
+            res.status,
+            res.status_text,
+            res.header,
+        ))
     }
 }
 
@@ -1604,34 +1642,17 @@ impl megalodon::Megalodon for Friendica {
         options: Option<&megalodon::UploadMediaInputOptions>,
     ) -> Result<Response<MegalodonEntities::UploadMedia>, Error> {
         let file = File::open(file_path.clone()).await?;
-
         let file_name = hex::encode(Sha1::digest(file_path.as_bytes()));
+        self._upload_media(file_name, file, options).await
+    }
 
-        let stream = FramedRead::new(file, BytesCodec::new());
-        let file_body = reqwest::Body::wrap_stream(stream);
-        let part = reqwest::multipart::Part::stream(file_body).file_name(file_name);
-
-        let mut form = reqwest::multipart::Form::new().part("file", part);
-        if let Some(options) = options {
-            if let Some(description) = &options.description {
-                form = form.text("description", description.clone());
-            }
-            if let Some(focus) = &options.focus {
-                form = form.text("focus", focus.clone());
-            }
-        }
-
-        let res = self
-            .client
-            .post_multipart::<entities::Attachment>("/api/v2/media", form, None)
-            .await?;
-
-        Ok(Response::<MegalodonEntities::UploadMedia>::new(
-            res.json.into(),
-            res.status,
-            res.status_text,
-            res.header,
-        ))
+    async fn upload_media_bytes(
+        &self,
+        data: &'static [u8],
+        options: Option<&megalodon::UploadMediaInputOptions>,
+    ) -> Result<Response<MegalodonEntities::UploadMedia>, Error> {
+        let file_name = Uuid::new_v4().to_string();
+        self._upload_media(file_name, data, options).await
     }
 
     async fn get_media(

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -418,10 +418,17 @@ pub trait Megalodon {
     // ======================================
     // statuses/media
     // ======================================
-    /// Creates an attachment to be used with a new status.
+    /// Creates an attachment from file to be used with a new status.
     async fn upload_media(
         &self,
         file_path: String,
+        options: Option<&UploadMediaInputOptions>,
+    ) -> Result<Response<entities::UploadMedia>, Error>;
+
+    /// Creates an attachment from bytes to be used with a new status.
+    async fn upload_media_bytes(
+        &self,
+        data: &'static [u8],
         options: Option<&UploadMediaInputOptions>,
     ) -> Result<Response<entities::UploadMedia>, Error>;
 

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -18,8 +18,10 @@ use serde_json::Value;
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use tokio::fs::File;
+use tokio::io::AsyncRead;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use urlencoding::encode;
+use uuid::Uuid;
 
 /// Pleroma API Client which satisfies megalodon trait.
 #[derive(Debug, Clone)]
@@ -67,6 +69,43 @@ impl Pleroma {
             .set_response_type(&ResponseType::new("code".to_string()))
             .url();
         Ok(auth_url.to_string())
+    }
+
+    async fn _upload_media<'a, T>(
+        &'a self,
+        file_name: String,
+        reader: T,
+        options: Option<&'a megalodon::UploadMediaInputOptions>,
+    ) -> Result<Response<MegalodonEntities::UploadMedia>, Error>
+    where
+        T: AsyncRead + Send + Sync + 'static,
+    {
+        let stream = FramedRead::new(reader, BytesCodec::new());
+        let file_body = reqwest::Body::wrap_stream(stream);
+        let part = reqwest::multipart::Part::stream(file_body).file_name(file_name);
+
+        let mut form = reqwest::multipart::Form::new().part("file", part);
+        if let Some(options) = options {
+            if let Some(description) = &options.description {
+                form = form.text("description", description.clone());
+            }
+            if let Some(focus) = &options.focus {
+                form = form.text("focus", focus.clone());
+            }
+        }
+
+        let res = self
+            .client
+            .post_multipart::<entities::Attachment>("/api/v2/media", form, None)
+            .await?;
+
+        let data: MegalodonEntities::Attachment = res.json.into();
+        Ok(Response::<MegalodonEntities::UploadMedia>::new(
+            MegalodonEntities::UploadMedia::Attachment(data),
+            res.status,
+            res.status_text,
+            res.header,
+        ))
     }
 }
 
@@ -1792,35 +1831,17 @@ impl megalodon::Megalodon for Pleroma {
         options: Option<&megalodon::UploadMediaInputOptions>,
     ) -> Result<Response<MegalodonEntities::UploadMedia>, Error> {
         let file = File::open(file_path.clone()).await?;
-
         let file_name = hex::encode(Sha1::digest(file_path.as_bytes()));
+        self._upload_media(file_name, file, options).await
+    }
 
-        let stream = FramedRead::new(file, BytesCodec::new());
-        let file_body = reqwest::Body::wrap_stream(stream);
-        let part = reqwest::multipart::Part::stream(file_body).file_name(file_name);
-
-        let mut form = reqwest::multipart::Form::new().part("file", part);
-        if let Some(options) = options {
-            if let Some(description) = &options.description {
-                form = form.text("description", description.clone());
-            }
-            if let Some(focus) = &options.focus {
-                form = form.text("focus", focus.clone());
-            }
-        }
-
-        let res = self
-            .client
-            .post_multipart::<entities::Attachment>("/api/v2/media", form, None)
-            .await?;
-
-        let data: MegalodonEntities::Attachment = res.json.into();
-        Ok(Response::<MegalodonEntities::UploadMedia>::new(
-            MegalodonEntities::UploadMedia::Attachment(data),
-            res.status,
-            res.status_text,
-            res.header,
-        ))
+    async fn upload_media_bytes(
+        &self,
+        data: &'static [u8],
+        options: Option<&megalodon::UploadMediaInputOptions>,
+    ) -> Result<Response<MegalodonEntities::UploadMedia>, Error> {
+        let file_name = Uuid::new_v4().to_string();
+        self._upload_media(file_name, data, options).await
     }
 
     async fn get_media(


### PR DESCRIPTION
I found myself needing to upload media in memory (not from file on disk) so thought I'd take a bash at implementing this.

Not super happy with the design; ideally I wanted to have a generic upload_media method which took an `AsyncRead` reader, but the dyn trait stuff in `generator` seems to disallow this.
Also, the `&[u8]` having to be static is less than ideal!

Critique very much appreciated.