### PR TITLE
Add support for admin.sign_up notification type

### DIFF
--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -30,6 +30,7 @@ pub enum NotificationType {
     EmojiReaction,
     Update,
     Move,
+    AdminSignup,
 }
 
 impl fmt::Display for NotificationType {
@@ -46,6 +47,7 @@ impl fmt::Display for NotificationType {
             NotificationType::EmojiReaction => write!(f, "emoji_reaction"),
             NotificationType::Update => write!(f, "update"),
             NotificationType::Move => write!(f, "move"),
+            NotificationType::AdminSignup => write!(f, "admin.sign_up"),
         }
     }
 }
@@ -65,6 +67,7 @@ impl FromStr for NotificationType {
             "emoji_reaction" => Ok(NotificationType::EmojiReaction),
             "update" => Ok(NotificationType::Update),
             "move" => Ok(NotificationType::Move),
+            "admin.sign_up"  => Ok(NotificationType::AdminSignup),
             _ => Err(Error::new_own(s.to_owned(), Kind::ParseError, None, None)),
         }
     }

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -32,7 +32,6 @@ pub enum NotificationType {
     Move,
     AdminSignup,
     AdminReport,
-    AnnouncementReaction,
 }
 
 impl fmt::Display for NotificationType {
@@ -51,7 +50,6 @@ impl fmt::Display for NotificationType {
             NotificationType::Move => write!(f, "move"),
             NotificationType::AdminSignup => write!(f, "admin.sign_up"),
             NotificationType::AdminReport => write!(f, "admin.report"),
-            NotificationType::AnnouncementReaction => write!(f, "announcement.reaction"),
         }
     }
 }
@@ -73,7 +71,6 @@ impl FromStr for NotificationType {
             "move" => Ok(NotificationType::Move),
             "admin.sign_up" => Ok(NotificationType::AdminSignup),
             "admin.report" => Ok(NotificationType::AdminReport),
-            "announcement.reaction" => Ok(NotificationType::AnnouncementReaction),
             _ => Err(Error::new_own(s.to_owned(), Kind::ParseError, None, None)),
         }
     }

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -31,6 +31,8 @@ pub enum NotificationType {
     Update,
     Move,
     AdminSignup,
+    AdminReport,
+    AnnouncementReaction,
 }
 
 impl fmt::Display for NotificationType {
@@ -48,6 +50,8 @@ impl fmt::Display for NotificationType {
             NotificationType::Update => write!(f, "update"),
             NotificationType::Move => write!(f, "move"),
             NotificationType::AdminSignup => write!(f, "admin.sign_up"),
+            NotificationType::AdminReport => write!(f, "admin.report"),
+            NotificationType::AnnouncementReaction => write!(f, "announcement.reaction"),
         }
     }
 }
@@ -67,7 +71,9 @@ impl FromStr for NotificationType {
             "emoji_reaction" => Ok(NotificationType::EmojiReaction),
             "update" => Ok(NotificationType::Update),
             "move" => Ok(NotificationType::Move),
-            "admin.sign_up"  => Ok(NotificationType::AdminSignup),
+            "admin.sign_up" => Ok(NotificationType::AdminSignup),
+            "admin.report" => Ok(NotificationType::AdminReport),
+            "announcement.reaction" => Ok(NotificationType::AnnouncementReaction),
             _ => Err(Error::new_own(s.to_owned(), Kind::ParseError, None, None)),
         }
     }

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -23,6 +23,8 @@ pub enum NotificationType {
     Poll,
     Status,
     Update,
+    #[serde(rename = "admin.sign_up")]
+    AdminSignup,
 }
 
 impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
@@ -42,6 +44,7 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             }
             NotificationType::Status => MegalodonEntities::notification::NotificationType::Status,
             NotificationType::Update => MegalodonEntities::notification::NotificationType::Update,
+            NotificationType::AdminSignup => MegalodonEntities::notification::NotificationType::AdminSignup,
         }
     }
 }

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -25,6 +25,10 @@ pub enum NotificationType {
     Update,
     #[serde(rename = "admin.sign_up")]
     AdminSignup,
+    #[serde(rename = "admin.report")]
+    AdminReport,
+    #[serde(rename = "announcement.reaction")]
+    AnnouncementReaction,
 }
 
 impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
@@ -44,7 +48,15 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             }
             NotificationType::Status => MegalodonEntities::notification::NotificationType::Status,
             NotificationType::Update => MegalodonEntities::notification::NotificationType::Update,
-            NotificationType::AdminSignup => MegalodonEntities::notification::NotificationType::AdminSignup,
+            NotificationType::AdminSignup => {
+                MegalodonEntities::notification::NotificationType::AdminSignup
+            }
+            NotificationType::AdminReport => {
+                MegalodonEntities::notification::NotificationType::AdminReport
+            }
+            NotificationType::AnnouncementReaction => {
+                MegalodonEntities::notification::NotificationType::AnnouncementReaction
+            }
         }
     }
 }

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -27,8 +27,6 @@ pub enum NotificationType {
     AdminSignup,
     #[serde(rename = "admin.report")]
     AdminReport,
-    #[serde(rename = "announcement.reaction")]
-    AnnouncementReaction,
 }
 
 impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
@@ -53,9 +51,6 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
             }
             NotificationType::AdminReport => {
                 MegalodonEntities::notification::NotificationType::AdminReport
-            }
-            NotificationType::AnnouncementReaction => {
-                MegalodonEntities::notification::NotificationType::AnnouncementReaction
             }
         }
     }


### PR DESCRIPTION
Mastodon will send an `admin.sign_up` type notification when an admin signup happens. This causes serde deserialization to fail.

This small change adds an `AdminSignup` variant to the `NotificationType` enum.

_(Be kind when reviewing this PR, as this is my first Rust project and I have only been writing Rust code for two months)._