### PR TITLE
Update Rust crate serde to 1.0.184

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.11", features = ["json", "multipart", "stream"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7.8", features = ["codec"] }
 serde_json = "1.0.104"
-serde = { version = "1.0.183", features = ["derive"]}
+serde = { version = "1.0.184", features = ["derive"]}
 url = "2.4.0"
 oauth2 = { version = "4.4" }
 sha1 = { version = "0.10" }


### PR DESCRIPTION
This includes PR #2538 (using serde_derive without precompiled binary)