### PR TITLE
Put type param into options in search

### DIFF
--- a/examples/mastodon_search.rs
+++ b/examples/mastodon_search.rs
@@ -1,0 +1,56 @@
+use std::env;
+
+use megalodon::{
+    entities, error, generator,
+    megalodon::{SearchInputOptions, SearchType},
+};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let Ok(url) = env::var("MASTODON_URL") else {
+        println!("Specify MASTODON_URL!!");
+        return
+    };
+    let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
+        println!("Specify MASTODON_ACCESS_TOKEN!!");
+        return
+    };
+
+    let res = search(url.as_str(), token, "h3poteto").await;
+    match res {
+        Ok(res) => {
+            println!("{:#?}", res);
+        }
+        Err(err) => {
+            println!("{:#?}", err);
+        }
+    }
+}
+
+async fn search(
+    url: &str,
+    access_token: String,
+    query: &str,
+) -> Result<entities::Results, error::Error> {
+    let client = generator(
+        megalodon::SNS::Mastodon,
+        url.to_string(),
+        Some(access_token),
+        None,
+    );
+    let options = SearchInputOptions {
+        r#type: Some(SearchType::Accounts),
+        limit: None,
+        max_id: None,
+        min_id: None,
+        resolve: Some(true),
+        offset: None,
+        following: None,
+        account_id: None,
+        exclude_unreviewed: None,
+    };
+    let res = client.search(query.to_string(), Some(&options)).await?;
+    Ok(res.json())
+}

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -2434,11 +2434,13 @@ impl megalodon::Megalodon for Friendica {
     async fn search(
         &self,
         q: String,
-        r#type: &megalodon::SearchType,
         options: Option<&megalodon::SearchInputOptions>,
     ) -> Result<Response<MegalodonEntities::Results>, Error> {
-        let mut params = Vec::<String>::from([format!("q={}", q), format!("type={}", r#type)]);
+        let mut params = Vec::<String>::from([format!("q={}", q)]);
         if let Some(options) = options {
+            if let Some(t) = &options.r#type {
+                params.push(format!("type={}", t));
+            }
             if let Some(limit) = options.limit {
                 params.push(format!("limit={}", limit));
             }

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -2722,11 +2722,13 @@ impl megalodon::Megalodon for Mastodon {
     async fn search(
         &self,
         q: String,
-        r#type: &megalodon::SearchType,
         options: Option<&megalodon::SearchInputOptions>,
     ) -> Result<Response<MegalodonEntities::Results>, Error> {
-        let mut params = Vec::<String>::from([format!("q={}", q), format!("type={}", r#type)]);
+        let mut params = Vec::<String>::from([format!("q={}", q)]);
         if let Some(options) = options {
+            if let Some(t) = &options.r#type {
+                params.push(format!("type={}", t));
+            }
             if let Some(limit) = options.limit {
                 params.push(format!("limit={}", limit));
             }

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -636,7 +636,6 @@ pub trait Megalodon {
     async fn search(
         &self,
         q: String,
-        r#type: &SearchType,
         options: Option<&SearchInputOptions>,
     ) -> Result<Response<entities::Results>, Error>;
 
@@ -1187,6 +1186,8 @@ impl FromStr for SearchType {
 /// Input options for [`Megalodon::search`].
 #[derive(Debug, Clone, Default)]
 pub struct SearchInputOptions {
+    /// Specify whether to search for only accounts, hashtags, statuses.
+    pub r#type: Option<SearchType>,
     /// Maximum number of results. Default 20, max 40.
     pub limit: Option<u32>,
     /// Return results oder than this id.

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -2646,11 +2646,13 @@ impl megalodon::Megalodon for Pleroma {
     async fn search(
         &self,
         q: String,
-        r#type: &megalodon::SearchType,
         options: Option<&megalodon::SearchInputOptions>,
     ) -> Result<Response<MegalodonEntities::Results>, Error> {
-        let mut params = Vec::<String>::from([format!("q={}", q), format!("type={}", r#type)]);
+        let mut params = Vec::<String>::from([format!("q={}", q)]);
         if let Some(options) = options {
+            if let Some(t) = &options.r#type {
+                params.push(format!("type={}", t));
+            }
             if let Some(limit) = options.limit {
                 params.push(format!("limit={}", limit));
             }


### PR DESCRIPTION
`type` is an optional field according to the Mastodon document.
https://docs.joinmastodon.org/methods/search/