### PR TITLE
Ignore errors in Firefish search

### DIFF
--- a/examples/firefish_search.rs
+++ b/examples/firefish_search.rs
@@ -1,0 +1,39 @@
+use std::env;
+
+use megalodon::{entities, error, generator};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let Ok(url) = env::var("FIREFISH_URL") else {
+        println!("Specify FIREFISH_URL!!");
+        return;
+    };
+    let Ok(token) = env::var("FIREFISH_ACCESS_TOKEN") else {
+        println!("Specify FIREFISH_ACCESS_TOKEN!!");
+        return;
+    };
+
+    let res = search(url.as_str(), token).await;
+    match res {
+        Ok(res) => {
+            println!("{:#?}", res);
+        }
+        Err(err) => {
+            println!("{:#?}", err);
+        }
+    }
+}
+
+async fn search(url: &str, access_token: String) -> Result<entities::Results, error::Error> {
+    let client = generator(
+        megalodon::SNS::Firefish,
+        url.to_string(),
+        Some(access_token),
+        None,
+    );
+    let res = client.search(String::from("h3poteto"), None).await?;
+
+    Ok(res.json())
+}

--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -212,18 +212,39 @@ impl Firefish {
         q: String,
         options: Option<&megalodon::SearchInputOptions>,
     ) -> Result<Response<MegalodonEntities::Results>, Error> {
-        let accounts = self.search_accounts(q.clone(), options).await?;
-        let hashtags = self.search_hashtags(q.clone(), options).await?;
-        let statuses = self.search_statuses(q, options).await?;
+        let accounts = self
+            .search_accounts(q.clone(), options)
+            .await
+            .map(|r| r.json)
+            .unwrap_or_else(|e| {
+                log::warn!("{}", e);
+                [].to_vec()
+            });
+        let hashtags = self
+            .search_hashtags(q.clone(), options)
+            .await
+            .map(|r| r.json)
+            .unwrap_or_else(|e| {
+                log::warn!("{}", e);
+                [].to_vec()
+            });
+        let statuses = self
+            .search_statuses(q, options)
+            .await
+            .map(|r| r.json)
+            .unwrap_or_else(|e| {
+                log::warn!("{}", e);
+                [].to_vec()
+            });
         Ok(Response::<MegalodonEntities::Results>::new(
             MegalodonEntities::Results {
-                accounts: accounts.json.into_iter().map(|i| i.into()).collect(),
-                statuses: statuses.json.into_iter().map(|i| i.into()).collect(),
-                hashtags: hashtags.json.into_iter().map(|i| i.into()).collect(),
+                accounts: accounts.into_iter().map(|i| i.into()).collect(),
+                statuses: statuses.into_iter().map(|i| i.into()).collect(),
+                hashtags: hashtags.into_iter().map(|i| i.into()).collect(),
             },
-            accounts.status,
-            accounts.status_text,
-            accounts.header,
+            200,
+            String::from("200"),
+            reqwest::header::HeaderMap::default(),
         ))
     }
 }


### PR DESCRIPTION
Even if status search fails, it should return accounts and hashtags results.