### PR TITLE
fix: disable default features for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustls-tls = ["tokio-tungstenite/rustls-tls-native-roots", "reqwest/rustls-tls",
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1.75"
-reqwest = { version = "0.11", features = ["json", "multipart", "stream"] }
+reqwest = { version = "0.11", features = ["json", "multipart", "stream"], default-features =  false }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 serde_json = "1.0.108"


### PR DESCRIPTION
If your project depends on `megalodon` your `cargo tree` looked like this:
```
├── megalodon v0.11.7
│   ├── async-trait v0.1.75 (proc-macro) (*)
│   ├── chrono v0.4.31 (*)
│   ├── futures-util v0.3.29 (*)
│   ├── hex v0.4.3
│   ├── http v0.2.11
│   │   ├── bytes v1.5.0
│   │   ├── fnv v1.0.7
│   │   └── itoa v1.0.10
│   ├── log v0.4.20
│   ├── oauth2 v4.4.2
│   │   ├── base64 v0.13.1
│   │   ├── chrono v0.4.31 (*)
│   │   ├── http v0.2.11 (*)
│   │   ├── rand v0.8.5 (*)
│   │   ├── reqwest v0.11.22
│   │   │   ├── base64 v0.21.5
│   │   │   ├── bytes v1.5.0
│   │   │   ├── encoding_rs v0.8.33
│   │   │   │   └── cfg-if v1.0.0
│   │   │   ├── futures-core v0.3.29
│   │   │   ├── futures-util v0.3.29 (*)
│   │   │   ├── h2 v0.3.22
│   │   │   │   ├── bytes v1.5.0
│   │   │   │   ├── fnv v1.0.7
│   │   │   │   ├── futures-core v0.3.29
│   │   │   │   ├── futures-sink v0.3.29
│   │   │   │   ├── futures-util v0.3.29 (*)
│   │   │   │   ├── http v0.2.11 (*)
│   │   │   │   ├── indexmap v2.1.0 (*)
│   │   │   │   ├── slab v0.4.9 (*)
│   │   │   │   ├── tokio v1.35.0 (*)
│   │   │   │   ├── tokio-util v0.7.10 (*)
│   │   │   │   └── tracing v0.1.40 (*)
│   │   │   ├── http v0.2.11 (*)
│   │   │   ├── http-body v0.4.6
│   │   │   │   ├── bytes v1.5.0
│   │   │   │   ├── http v0.2.11 (*)
│   │   │   │   └── pin-project-lite v0.2.13
│   │   │   ├── hyper v0.14.27
│   │   │   │   ├── bytes v1.5.0
│   │   │   │   ├── futures-channel v0.3.29 (*)
│   │   │   │   ├── futures-core v0.3.29
│   │   │   │   ├── futures-util v0.3.29 (*)
│   │   │   │   ├── h2 v0.3.22 (*)
│   │   │   │   ├── http v0.2.11 (*)
│   │   │   │   ├── http-body v0.4.6 (*)
│   │   │   │   ├── httparse v1.8.0
│   │   │   │   ├── httpdate v1.0.3
│   │   │   │   ├── itoa v1.0.10
│   │   │   │   ├── pin-project-lite v0.2.13
│   │   │   │   ├── socket2 v0.4.10
│   │   │   │   │   └── libc v0.2.151
│   │   │   │   ├── tokio v1.35.0 (*)
│   │   │   │   ├── tower-service v0.3.2
│   │   │   │   ├── tracing v0.1.40 (*)
│   │   │   │   └── want v0.3.1
│   │   │   │       └── try-lock v0.2.5
│   │   │   ├── hyper-rustls v0.24.2
│   │   │   │   ├── futures-util v0.3.29 (*)
│   │   │   │   ├── http v0.2.11 (*)
│   │   │   │   ├── hyper v0.14.27 (*)
│   │   │   │   ├── log v0.4.20
│   │   │   │   ├── rustls v0.21.10
│   │   │   │   │   ├── log v0.4.20
│   │   │   │   │   ├── ring v0.17.7
│   │   │   │   │   │   ├── getrandom v0.2.11 (*)
│   │   │   │   │   │   ├── spin v0.9.8
│   │   │   │   │   │   └── untrusted v0.9.0
│   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   └── cc v1.0.83
│   │   │   │   │   │       └── libc v0.2.151
│   │   │   │   │   ├── rustls-webpki v0.101.7
│   │   │   │   │   │   ├── ring v0.17.7 (*)
│   │   │   │   │   │   └── untrusted v0.9.0
│   │   │   │   │   └── sct v0.7.1
│   │   │   │   │       ├── ring v0.17.7 (*)
│   │   │   │   │       └── untrusted v0.9.0
│   │   │   │   ├── rustls-native-certs v0.6.3
│   │   │   │   │   ├── openssl-probe v0.1.5
│   │   │   │   │   └── rustls-pemfile v1.0.4
│   │   │   │   │       └── base64 v0.21.5
│   │   │   │   ├── tokio v1.35.0 (*)
│   │   │   │   └── tokio-rustls v0.24.1
│   │   │   │       ├── rustls v0.21.10 (*)
│   │   │   │       └── tokio v1.35.0 (*)
│   │   │   ├── hyper-tls v0.5.0
│   │   │   │   ├── bytes v1.5.0
│   │   │   │   ├── hyper v0.14.27 (*)
│   │   │   │   ├── native-tls v0.2.11
│   │   │   │   │   ├── log v0.4.20
│   │   │   │   │   ├── openssl v0.10.61
│   │   │   │   │   │   ├── bitflags v2.4.1
│   │   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   │   ├── foreign-types v0.3.2
│   │   │   │   │   │   │   └── foreign-types-shared v0.1.1
│   │   │   │   │   │   ├── libc v0.2.151
│   │   │   │   │   │   ├── once_cell v1.19.0
│   │   │   │   │   │   ├── openssl-macros v0.1.1 (proc-macro)
│   │   │   │   │   │   │   ├── proc-macro2 v1.0.70 (*)
│   │   │   │   │   │   │   ├── quote v1.0.33 (*)
│   │   │   │   │   │   │   └── syn v2.0.41 (*)
│   │   │   │   │   │   └── openssl-sys v0.9.97
│   │   │   │   │   │       └── libc v0.2.151
│   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │       ├── cc v1.0.83 (*)
│   │   │   │   │   │       ├── pkg-config v0.3.27
│   │   │   │   │   │       └── vcpkg v0.2.15
│   │   │   │   │   ├── openssl-probe v0.1.5
│   │   │   │   │   └── openssl-sys v0.9.97 (*)
│   │   │   │   ├── tokio v1.35.0 (*)
│   │   │   │   └── tokio-native-tls v0.3.1
│   │   │   │       ├── native-tls v0.2.11 (*)
│   │   │   │       └── tokio v1.35.0 (*)
```

As you can see does `reqwest` depends on `hyper-rustls` AND `hyper-tls`. The reason for this behaviour is that `reqwest` has  native-tls as a default feature. If you want to configure them manually you must disable them otherwise you will have both.