### PR TITLE
Parse pleroma custom emoji reactions in notifications

### DIFF
--- a/examples/firefish_notifications.rs
+++ b/examples/firefish_notifications.rs
@@ -1,0 +1,41 @@
+use std::env;
+
+use megalodon::{entities, error, generator};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let Ok(url) = env::var("FIREFISH_URL") else {
+        println!("Specify FIREFISH_URL!!");
+        return;
+    };
+    let Ok(token) = env::var("FIREFISH_ACCESS_TOKEN") else {
+        println!("Specify FIREFISH_ACCESS_TOKEN!!");
+        return;
+    };
+
+    let res = get_notifications(url.as_str(), token).await;
+    match res {
+        Ok(res) => {
+            println!("{:#?}", res);
+        }
+        Err(err) => {
+            println!("{:#?}", err);
+        }
+    }
+}
+
+async fn get_notifications(
+    url: &str,
+    access_token: String,
+) -> Result<Vec<entities::Notification>, error::Error> {
+    let client = generator(
+        megalodon::SNS::Firefish,
+        url.to_string(),
+        Some(access_token),
+        None,
+    );
+    let res = client.get_notifications(None).await?;
+    Ok(res.json())
+}

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -226,7 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detector_firefish() {
-        let sns = detector("https://calckey.jp").await;
+        let sns = detector("https://calckey.world").await;
 
         assert!(sns.is_ok());
         assert_eq!(sns.unwrap(), SNS::Firefish);

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -11,7 +11,6 @@ pub struct Notification {
     pub created_at: DateTime<Utc>,
     pub id: String,
     pub status: Option<Status>,
-    pub emoji: Option<String>,
     pub reaction: Option<Reaction>,
     pub target: Option<Account>,
     pub r#type: NotificationType,
@@ -28,9 +27,6 @@ pub enum NotificationType {
     PollVote,
     PollExpired,
     Status,
-    // EmojiReaction contains only emoji as string.
-    EmojiReaction,
-    // Reaction contains reaction object instead of emoji.
     Reaction,
     Update,
     Move,
@@ -52,7 +48,6 @@ impl fmt::Display for NotificationType {
             NotificationType::PollExpired => write!(f, "poll_expired"),
             NotificationType::FollowRequest => write!(f, "follow_request"),
             NotificationType::Status => write!(f, "status"),
-            NotificationType::EmojiReaction => write!(f, "emoji_reaction"),
             NotificationType::Reaction => write!(f, "reaction"),
             NotificationType::Update => write!(f, "update"),
             NotificationType::Move => write!(f, "move"),
@@ -77,7 +72,6 @@ impl FromStr for NotificationType {
             "poll_vote" => Ok(NotificationType::PollVote),
             "follow_request" => Ok(NotificationType::FollowRequest),
             "status" => Ok(NotificationType::Status),
-            "emoji_reaction" => Ok(NotificationType::EmojiReaction),
             "reaction" => Ok(NotificationType::Reaction),
             "update" => Ok(NotificationType::Update),
             "move" => Ok(NotificationType::Move),

--- a/src/entities/reaction.rs
+++ b/src/entities/reaction.rs
@@ -10,4 +10,5 @@ pub struct Reaction {
     pub url: Option<String>,
     pub static_url: Option<String>,
     pub accounts: Option<Vec<Account>>,
+    pub account_ids: Option<Vec<String>>,
 }

--- a/src/firefish/entities/notification.rs
+++ b/src/firefish/entities/notification.rs
@@ -17,7 +17,7 @@ pub struct Notification {
     // user_id: Option<String>,
     user: Option<User>,
     note: Option<Note>,
-    reaction: String,
+    reaction: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -64,9 +64,6 @@ impl From<MegalodonEntities::notification::NotificationType> for NotificationTyp
             MegalodonEntities::notification::NotificationType::Follow => NotificationType::Follow,
             MegalodonEntities::notification::NotificationType::Mention => NotificationType::Mention,
             MegalodonEntities::notification::NotificationType::Reblog => NotificationType::Renote,
-            MegalodonEntities::notification::NotificationType::EmojiReaction => {
-                NotificationType::Reaction
-            }
             MegalodonEntities::notification::NotificationType::Reaction => {
                 NotificationType::Reaction
             }
@@ -139,11 +136,11 @@ impl Into<MegalodonEntities::Notification> for Notification {
         } else {
             [].to_vec()
         };
-        let reactions = map_reaction(
-            emojis,
-            HashMap::<String, u32>::from([(self.reaction, 1)]),
-            None,
-        );
+        let reactions = if let Some(reaction) = self.reaction {
+            map_reaction(emojis, HashMap::<String, u32>::from([(reaction, 1)]), None)
+        } else {
+            [].to_vec()
+        };
         let reaction = if reactions.len() > 0 {
             Some(reactions[0].clone())
         } else {
@@ -154,7 +151,6 @@ impl Into<MegalodonEntities::Notification> for Notification {
             created_at: self.created_at,
             id: self.id,
             status: self.note.map(|n| n.into()),
-            emoji: None,
             reaction,
             target: None,
             r#type: self.r#type.into(),

--- a/src/firefish/entities/reaction.rs
+++ b/src/firefish/entities/reaction.rs
@@ -38,6 +38,7 @@ pub(crate) fn map_reaction(
                 url: url.clone(),
                 static_url: url,
                 accounts: None,
+                account_ids: None,
             }
         })
         .collect()

--- a/src/firefish/entities/reaction.rs
+++ b/src/firefish/entities/reaction.rs
@@ -94,6 +94,7 @@ mod test {
                 url: Some(String::from("https://example.com/files/ablobcatnodfast")),
                 static_url: Some(String::from("https://example.com/files/ablobcatnodfast")),
                 accounts: None,
+                account_ids: None,
             },
         );
 
@@ -115,6 +116,7 @@ mod test {
                     "https://example.com/proxy/firefishexample/kawaii"
                 )),
                 accounts: None,
+                account_ids: None,
             }
         );
     }
@@ -144,6 +146,7 @@ mod test {
                 url: None,
                 static_url: None,
                 accounts: None,
+                account_ids: None,
             },
         );
 
@@ -161,6 +164,7 @@ mod test {
                 url: None,
                 static_url: None,
                 accounts: None,
+                account_ids: None,
             }
         );
     }
@@ -211,6 +215,7 @@ mod test {
                 url: Some(String::from("https://example.com/files/ablobcatnodfast")),
                 static_url: Some(String::from("https://example.com/files/ablobcatnodfast")),
                 accounts: None,
+                account_ids: None,
             },
         );
 
@@ -232,6 +237,7 @@ mod test {
                     "https://example.com/proxy/firefishexample/kawaii"
                 )),
                 accounts: None,
+                account_ids: None,
             }
         );
     }

--- a/src/friendica/entities/notification.rs
+++ b/src/friendica/entities/notification.rs
@@ -53,7 +53,6 @@ impl Into<MegalodonEntities::Notification> for Notification {
             created_at: self.created_at,
             id: self.id,
             status: self.status.map(|i| i.into()),
-            emoji: None,
             reaction: None,
             target: None,
             r#type: self.r#type.into(),

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -63,7 +63,6 @@ impl Into<MegalodonEntities::Notification> for Notification {
             created_at: self.created_at,
             id: self.id,
             status: self.status.map(|i| i.into()),
-            emoji: None,
             reaction: None,
             target: None,
             r#type: self.r#type.into(),

--- a/src/pleroma/entities/reaction.rs
+++ b/src/pleroma/entities/reaction.rs
@@ -4,10 +4,12 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Reaction {
-    count: u32,
-    me: bool,
-    name: String,
-    accounts: Option<Vec<Account>>,
+    pub count: u32,
+    pub me: bool,
+    pub name: String,
+    pub accounts: Option<Vec<Account>>,
+    pub account_ids: Option<Vec<String>>,
+    pub url: Option<String>,
 }
 
 impl Into<MegalodonEntities::Reaction> for Reaction {
@@ -16,10 +18,12 @@ impl Into<MegalodonEntities::Reaction> for Reaction {
             count: self.count,
             me: self.me,
             name: self.name,
-            url: None,
-            static_url: None,
+            url: self.url.clone(),
+            static_url: self.url,
+            account_ids: self.account_ids,
             accounts: self
                 .accounts
+                .clone()
                 .map(|i| i.into_iter().map(|a| a.into()).collect()),
         }
     }


### PR DESCRIPTION
Currently, Pleroma supports custom emoji reactions. 
I parsed custom emoji reactions to Reaction object that is shared with Firefish. As a result, `emoji` filed in Notification is deleted, please use `reaction` field instead.