### PR TITLE
Infer streaming URL from instance information

### DIFF
--- a/examples/firefish_streaming.rs
+++ b/examples/firefish_streaming.rs
@@ -6,8 +6,8 @@ use megalodon::{generator, streaming::Message};
 async fn main() {
     env_logger::init();
 
-    let Ok(url) = env::var("FIREFISH_STREAMING_URL") else {
-        println!("Specify FIREFISH_STREAMING_URL!!");
+    let Ok(url) = env::var("FIREFISH_URL") else {
+        println!("Specify FIREFISH_URL!!");
         return;
     };
     let Ok(token) = env::var("FIREFISH_ACCESS_TOKEN") else {
@@ -25,7 +25,7 @@ async fn streaming(url: &str, access_token: String) {
         Some(access_token),
         None,
     );
-    let streaming = client.local_streaming(url.to_string());
+    let streaming = client.local_streaming().await;
 
     streaming
         .listen(Box::new(|message| match message {

--- a/examples/mastodon_streaming.rs
+++ b/examples/mastodon_streaming.rs
@@ -5,13 +5,13 @@ use std::env;
 async fn main() {
     env_logger::init();
 
-    let Ok(url) = env::var("MASTODON_STREAMING_URL") else {
-        println!("Specify MASTODON_STREAMING_URL!!");
-        return
+    let Ok(url) = env::var("MASTODON_URL") else {
+        println!("Specify MASTODON_URL!!");
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     streaming(url.as_str(), token).await;
@@ -24,7 +24,7 @@ async fn streaming(url: &str, access_token: String) {
         Some(access_token),
         None,
     );
-    let streaming = client.local_streaming(url.to_string());
+    let streaming = client.local_streaming().await;
 
     streaming
         .listen(Box::new(|message| match message {

--- a/examples/mastodon_unauthorized_local.rs
+++ b/examples/mastodon_unauthorized_local.rs
@@ -5,9 +5,9 @@ use std::env;
 async fn main() {
     env_logger::init();
 
-    let Ok(url) = env::var("MASTODON_STREAMING_URL") else {
-        println!("Specify MASTODON_STREAMING_URL!!");
-        return
+    let Ok(url) = env::var("MASTODON_URL") else {
+        println!("Specify MASTODON_URL!!");
+        return;
     };
 
     streaming(url.as_str()).await;
@@ -15,7 +15,7 @@ async fn main() {
 
 async fn streaming(url: &str) {
     let client = generator(megalodon::SNS::Mastodon, url.to_string(), None, None);
-    let streaming = client.local_streaming(url.to_string());
+    let streaming = client.local_streaming().await;
 
     streaming
         .listen(Box::new(|message| match message {

--- a/examples/pleroma_streaming.rs
+++ b/examples/pleroma_streaming.rs
@@ -5,13 +5,13 @@ use std::env;
 async fn main() {
     env_logger::init();
 
-    let Ok(url) = env::var("PLEROMA_STREAMING_URL") else {
-        println!("Specify PLEROMA_STREAMING_URL!!");
-        return
+    let Ok(url) = env::var("PLEROMA_URL") else {
+        println!("Specify PLEROMA_URL!!");
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     streaming(url.as_str(), token).await;
@@ -24,7 +24,7 @@ async fn streaming(url: &str, access_token: String) {
         Some(access_token),
         None,
     );
-    let streaming = client.user_streaming(url.to_string());
+    let streaming = client.user_streaming().await;
 
     streaming
         .listen(Box::new(|message| match message {

--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -2429,7 +2429,20 @@ impl megalodon::Megalodon for Firefish {
         ))
     }
 
-    fn user_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn streaming_url(&self) -> String {
+        let instance = self.get_instance().await;
+        if let Ok(instance) = instance {
+            match instance.json.urls {
+                Some(urls) => return urls.streaming_api,
+                _ => {}
+            };
+        }
+
+        self.base_url.clone()
+    }
+
+    async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("user"),
@@ -2441,7 +2454,8 @@ impl megalodon::Megalodon for Firefish {
         Box::new(c)
     }
 
-    fn public_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("globalTimeline"),
@@ -2453,7 +2467,8 @@ impl megalodon::Megalodon for Firefish {
         Box::new(c)
     }
 
-    fn local_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("localTimeline"),
@@ -2465,7 +2480,8 @@ impl megalodon::Megalodon for Firefish {
         Box::new(c)
     }
 
-    fn direct_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("conversation"),
@@ -2477,11 +2493,8 @@ impl megalodon::Megalodon for Firefish {
         Box::new(c)
     }
 
-    fn tag_streaming(
-        &self,
-        streaming_url: String,
-        _tag: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn tag_streaming(&self, _tag: String) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("hashtag"),
@@ -2493,11 +2506,8 @@ impl megalodon::Megalodon for Firefish {
         Box::new(c)
     }
 
-    fn list_streaming(
-        &self,
-        streaming_url: String,
-        list_id: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn list_streaming(&self, list_id: String) -> Box<dyn Streaming + Send + Sync> {
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/streaming",
             String::from("list"),

--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -2444,7 +2444,7 @@ impl megalodon::Megalodon for Firefish {
     async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("user"),
             None,
             self.access_token.clone(),
@@ -2457,7 +2457,7 @@ impl megalodon::Megalodon for Firefish {
     async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("globalTimeline"),
             None,
             self.access_token.clone(),
@@ -2470,7 +2470,7 @@ impl megalodon::Megalodon for Firefish {
     async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("localTimeline"),
             None,
             self.access_token.clone(),
@@ -2483,7 +2483,7 @@ impl megalodon::Megalodon for Firefish {
     async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("conversation"),
             None,
             self.access_token.clone(),
@@ -2496,7 +2496,7 @@ impl megalodon::Megalodon for Firefish {
     async fn tag_streaming(&self, _tag: String) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("hashtag"),
             None,
             self.access_token.clone(),
@@ -2509,7 +2509,7 @@ impl megalodon::Megalodon for Firefish {
     async fn list_streaming(&self, list_id: String) -> Box<dyn Streaming + Send + Sync> {
         let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
-            streaming_url + "/streaming",
+            streaming_url,
             String::from("list"),
             Some(list_id),
             self.access_token.clone(),

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -2692,45 +2692,49 @@ impl megalodon::Megalodon for Friendica {
         ))
     }
 
-    fn user_streaming(&self, _streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn streaming_url(&self) -> String {
+        let instance = self.get_instance().await;
+        if let Ok(instance) = instance {
+            match instance.json.urls {
+                Some(urls) => return urls.streaming_api,
+                _ => {}
+            };
+        }
+
+        self.base_url.clone()
+    }
+
+    async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)
     }
 
-    fn public_streaming(&self, _streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)
     }
 
-    fn local_streaming(&self, _streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)
     }
 
-    fn direct_streaming(&self, _streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)
     }
 
-    fn tag_streaming(
-        &self,
-        _streaming_url: String,
-        _tag: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn tag_streaming(&self, _tag: String) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)
     }
 
-    fn list_streaming(
-        &self,
-        _streaming_url: String,
-        _list_id: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn list_streaming(&self, _list_id: String) -> Box<dyn Streaming + Send + Sync> {
         let c = WebSocket::new();
 
         Box::new(c)

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -3020,8 +3020,21 @@ impl megalodon::Megalodon for Mastodon {
         ))
     }
 
-    fn user_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn streaming_url(&self) -> String {
+        let instance = self.get_instance().await;
+        if let Ok(instance) = instance {
+            match instance.json.urls {
+                Some(urls) => return urls.streaming_api,
+                _ => {}
+            };
+        }
+
+        self.base_url.clone()
+    }
+
+    async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("user"),
@@ -3033,8 +3046,9 @@ impl megalodon::Megalodon for Mastodon {
         Box::new(c)
     }
 
-    fn public_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("public"),
@@ -3046,8 +3060,9 @@ impl megalodon::Megalodon for Mastodon {
         Box::new(c)
     }
 
-    fn local_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("public:local"),
@@ -3059,8 +3074,9 @@ impl megalodon::Megalodon for Mastodon {
         Box::new(c)
     }
 
-    fn direct_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("direct"),
@@ -3072,12 +3088,9 @@ impl megalodon::Megalodon for Mastodon {
         Box::new(c)
     }
 
-    fn tag_streaming(
-        &self,
-        streaming_url: String,
-        tag: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn tag_streaming(&self, tag: String) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::from([format!("tag={}", tag)]);
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("hashtag"),
@@ -3089,12 +3102,9 @@ impl megalodon::Megalodon for Mastodon {
         Box::new(c)
     }
 
-    fn list_streaming(
-        &self,
-        streaming_url: String,
-        list_id: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn list_streaming(&self, list_id: String) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::from([format!("list={}", list_id)]);
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("list"),

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -744,28 +744,26 @@ pub trait Megalodon {
     // ======================================
     // Streaming
     // ======================================
+    /// Get the base URL for streaming endpoints
+    async fn streaming_url(&self) -> String;
+
     /// Get user streaming object.
-    fn user_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync>;
+    async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync>;
 
     /// Get public streaming object.
-    fn public_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync>;
+    async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync>;
 
     /// Get local streaming object.
-    fn local_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync>;
+    async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync>;
 
     /// Get direct streaming object.
-    fn direct_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync>;
+    async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync>;
 
     /// Get tag streaming object.
-    fn tag_streaming(&self, streaming_url: String, tag: String)
-        -> Box<dyn Streaming + Send + Sync>;
+    async fn tag_streaming(&self, tag: String) -> Box<dyn Streaming + Send + Sync>;
 
     /// Get list streaming object.
-    fn list_streaming(
-        &self,
-        streaming_url: String,
-        list_id: String,
-    ) -> Box<dyn Streaming + Send + Sync>;
+    async fn list_streaming(&self, list_id: String) -> Box<dyn Streaming + Send + Sync>;
 }
 
 /// Input options for [`Megalodon::register_app`] and [`Megalodon::create_app`].

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -2976,8 +2976,21 @@ impl megalodon::Megalodon for Pleroma {
         ))
     }
 
-    fn user_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn streaming_url(&self) -> String {
+        let instance = self.get_instance().await;
+        if let Ok(instance) = instance {
+            match instance.json.urls {
+                Some(urls) => return urls.streaming_api,
+                _ => {}
+            };
+        }
+
+        self.base_url.clone()
+    }
+
+    async fn user_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("user"),
@@ -2989,8 +3002,9 @@ impl megalodon::Megalodon for Pleroma {
         Box::new(c)
     }
 
-    fn public_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn public_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("public"),
@@ -3002,8 +3016,9 @@ impl megalodon::Megalodon for Pleroma {
         Box::new(c)
     }
 
-    fn local_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn local_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("public:local"),
@@ -3015,8 +3030,9 @@ impl megalodon::Megalodon for Pleroma {
         Box::new(c)
     }
 
-    fn direct_streaming(&self, streaming_url: String) -> Box<dyn Streaming + Send + Sync> {
+    async fn direct_streaming(&self) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::new();
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("direct"),
@@ -3028,12 +3044,9 @@ impl megalodon::Megalodon for Pleroma {
         Box::new(c)
     }
 
-    fn tag_streaming(
-        &self,
-        streaming_url: String,
-        tag: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn tag_streaming(&self, tag: String) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::from([format!("tag={}", tag)]);
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("hashtag"),
@@ -3045,12 +3058,9 @@ impl megalodon::Megalodon for Pleroma {
         Box::new(c)
     }
 
-    fn list_streaming(
-        &self,
-        streaming_url: String,
-        list_id: String,
-    ) -> Box<dyn Streaming + Send + Sync> {
+    async fn list_streaming(&self, list_id: String) -> Box<dyn Streaming + Send + Sync> {
         let params = Vec::<String>::from([format!("list={}", list_id)]);
+        let streaming_url = self.streaming_url().await;
         let c = WebSocket::new(
             streaming_url + "/api/v1/streaming",
             String::from("list"),


### PR DESCRIPTION
This PR attempts to infer the base streaming URL from the instance information instead of needing to manually provide it separately. It does this by calling `get_instance()` and retrieving the `streaming_api` URL if available, otherwise it will use the `base_url` of the client.

This is obviously a breaking change, since the function signatures for all the streaming functions have all become `async` and the `streaming_url` parameter is removed.