### PR TITLE
implement From instead of Into

### DIFF
--- a/examples/detector.rs
+++ b/examples/detector.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let sns = detector(url.as_str()).await;
     println!("{:#?}", sns);

--- a/examples/friendica_authorization.rs
+++ b/examples/friendica_authorization.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
 
     let client = generator(megalodon::SNS::Friendica, url, None, None);

--- a/examples/friendica_credentials.rs
+++ b/examples/friendica_credentials.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
     match verify_credentials(url.as_str(), token).await {
         Ok(response) => {

--- a/examples/friendica_favourite.rs
+++ b/examples/friendica_favourite.rs
@@ -8,15 +8,15 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
     let Ok(status_id) = env::var("STATUS_ID") else {
         println!("Specify STATUS_ID!!");
-        return
+        return;
     };
 
     let res = favourite_status(url.as_str(), token, status_id).await;

--- a/examples/friendica_follow_requests.rs
+++ b/examples/friendica_follow_requests.rs
@@ -8,11 +8,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = follow_requests(url.as_str(), token).await;

--- a/examples/friendica_home.rs
+++ b/examples/friendica_home.rs
@@ -8,11 +8,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = home_timeline(url.as_str(), token).await;

--- a/examples/friendica_instance.rs
+++ b/examples/friendica_instance.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     match instance(url.as_str()).await {
         Ok(response) => {

--- a/examples/friendica_marker.rs
+++ b/examples/friendica_marker.rs
@@ -7,15 +7,15 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
     let Ok(notification_id) = env::var("NOTIFICATION_ID") else {
         println!("Specify NOTIFICATION_ID!!");
-        return
+        return;
     };
 
     let save = save_marker(url.as_str(), token.clone(), notification_id).await;

--- a/examples/friendica_media.rs
+++ b/examples/friendica_media.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let file_path = "./sample.jpg".to_string();

--- a/examples/friendica_post_with_media.rs
+++ b/examples/friendica_post_with_media.rs
@@ -11,11 +11,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let client = generator(megalodon::SNS::Friendica, url, Some(token), None);
@@ -23,7 +23,7 @@ async fn main() {
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path.to_string()).await else {
         println!("failed to upload media");
-        return
+        return;
     };
 
     let media_1: entities::Attachment;
@@ -45,7 +45,7 @@ async fn main() {
     let file_path = "./sample2.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path).await else {
         println!("error");
-        return
+        return;
     };
     let media_2: entities::Attachment;
     match res {

--- a/examples/friendica_reblog.rs
+++ b/examples/friendica_reblog.rs
@@ -8,15 +8,15 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
     let Ok(status_id) = env::var("STATUS_ID") else {
         println!("Specify STATUS_ID!!");
-        return
+        return;
     };
 
     let res = reblog_status(url.as_str(), token, status_id).await;

--- a/examples/friendica_relationship.rs
+++ b/examples/friendica_relationship.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("FRIENDICA_URL") else {
         println!("Specify FRIENDICA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("FRIENDICA_ACCESS_TOKEN") else {
         println!("Specify FRIENDICA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_relationship(url.as_str(), token, "2245768").await;

--- a/examples/mastodon_authorization.rs
+++ b/examples/mastodon_authorization.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let client = generator(megalodon::SNS::Mastodon, url, None, None);
     let options = megalodon::megalodon::AppInputOptions {

--- a/examples/mastodon_credentials.rs
+++ b/examples/mastodon_credentials.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
     match verify_credentials(url.as_str(), token).await {
         Ok(response) => {

--- a/examples/mastodon_instance.rs
+++ b/examples/mastodon_instance.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     match instance(url.as_str()).await {
         Ok(response) => {

--- a/examples/mastodon_marker.rs
+++ b/examples/mastodon_marker.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_markers(url.as_str(), token).await;

--- a/examples/mastodon_media.rs
+++ b/examples/mastodon_media.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let file_path = "./sample.jpg".to_string();

--- a/examples/mastodon_post_with_media.rs
+++ b/examples/mastodon_post_with_media.rs
@@ -11,11 +11,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let client = generator(megalodon::SNS::Mastodon, url, Some(token), None);
@@ -23,7 +23,7 @@ async fn main() {
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path.to_string()).await else {
         println!("failed to upload media");
-        return
+        return;
     };
 
     let media_1: entities::Attachment;
@@ -45,7 +45,7 @@ async fn main() {
     let file_path = "./sample2.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path).await else {
         println!("error");
-        return
+        return;
     };
     let media_2: entities::Attachment;
     match res {

--- a/examples/mastodon_relationship.rs
+++ b/examples/mastodon_relationship.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_relationship(url.as_str(), token, "109314016387492241").await;

--- a/examples/mastodon_search.rs
+++ b/examples/mastodon_search.rs
@@ -11,11 +11,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = search(url.as_str(), token, "h3poteto").await;

--- a/examples/mastodon_streaming.rs
+++ b/examples/mastodon_streaming.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_STREAMING_URL") else {
         println!("Specify MASTODON_STREAMING_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     streaming(url.as_str(), token).await;

--- a/examples/mastodon_unauthorized_local.rs
+++ b/examples/mastodon_unauthorized_local.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_STREAMING_URL") else {
         println!("Specify MASTODON_STREAMING_URL!!");
-        return
+        return;
     };
 
     streaming(url.as_str()).await;

--- a/examples/mastodon_update_credentials.rs
+++ b/examples/mastodon_update_credentials.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("MASTODON_URL") else {
         println!("Specify MASTODON_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("MASTODON_ACCESS_TOKEN") else {
         println!("Specify MASTODON_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let client = generator(SNS::Mastodon, url, Some(token), None);

--- a/examples/pleroma_authorization.rs
+++ b/examples/pleroma_authorization.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
 
     let client = generator(megalodon::SNS::Pleroma, url, None, None);

--- a/examples/pleroma_credentials.rs
+++ b/examples/pleroma_credentials.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     match verify_credentials(url.as_str(), token).await {

--- a/examples/pleroma_instance.rs
+++ b/examples/pleroma_instance.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     match instance(url.as_str()).await {
         Ok(response) => {

--- a/examples/pleroma_marker.rs
+++ b/examples/pleroma_marker.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_markers(url.as_str(), token).await;

--- a/examples/pleroma_notifications.rs
+++ b/examples/pleroma_notifications.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_notifications(url.as_str(), token).await;

--- a/examples/pleroma_post_with_media.rs
+++ b/examples/pleroma_post_with_media.rs
@@ -11,17 +11,17 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(url.as_str(), token.to_owned(), file_path.to_string()).await else {
         println!("failed to upload media");
-        return
+        return;
     };
     match res {
         entities::UploadMedia::AsyncAttachment(_) => {
@@ -32,7 +32,7 @@ async fn main() {
             let file_path = "./sample2.jpg".to_string();
             let Ok(res) = upload_media(url.as_str(), token.to_owned(), file_path).await else {
                 println!("failed to upload media");
-                return
+                return;
             };
             match res {
                 entities::UploadMedia::AsyncAttachment(_) => {

--- a/examples/pleroma_relationship.rs
+++ b/examples/pleroma_relationship.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_URL") else {
         println!("Specify PLEROMA_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     let res = get_relationship(url.as_str(), token, "4").await;

--- a/examples/pleroma_streaming.rs
+++ b/examples/pleroma_streaming.rs
@@ -7,11 +7,11 @@ async fn main() {
 
     let Ok(url) = env::var("PLEROMA_STREAMING_URL") else {
         println!("Specify PLEROMA_STREAMING_URL!!");
-        return
+        return;
     };
     let Ok(token) = env::var("PLEROMA_ACCESS_TOKEN") else {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
-        return
+        return;
     };
 
     streaming(url.as_str(), token).await;

--- a/src/entities/history.rs
+++ b/src/entities/history.rs
@@ -8,10 +8,10 @@ pub struct History {
 }
 
 pub fn parse_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-        T: std::str::FromStr,
-        <T as std::str::FromStr>::Err: std::fmt::Display,
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
 {
     Ok(String::deserialize(deserializer)?
         .parse()

--- a/src/firefish/entities/account.rs
+++ b/src/firefish/entities/account.rs
@@ -34,45 +34,45 @@ struct Emoji {
     visible_in_picker: bool,
 }
 
-impl Into<MegalodonEntities::Emoji> for Emoji {
-    fn into(self) -> MegalodonEntities::Emoji {
+impl From<Emoji> for MegalodonEntities::Emoji {
+    fn from(val: Emoji) -> Self {
         MegalodonEntities::Emoji {
-            shortcode: self.shortcode,
-            static_url: self.static_url,
-            url: self.url,
-            visible_in_picker: self.visible_in_picker,
+            shortcode: val.shortcode,
+            static_url: val.static_url,
+            url: val.url,
+            visible_in_picker: val.visible_in_picker,
             category: None,
         }
     }
 }
 
-impl Into<MegalodonEntities::Account> for Account {
-    fn into(self) -> MegalodonEntities::Account {
+impl From<Account> for MegalodonEntities::Account {
+    fn from(val: Account) -> Self {
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
-            acct: self.acct,
-            display_name: self.display_name,
-            locked: self.locked,
+            id: val.id,
+            username: val.username,
+            acct: val.acct,
+            display_name: val.display_name,
+            locked: val.locked,
             discoverable: None,
             group: None,
             noindex: None,
             moved: None,
             suspended: None,
             limited: None,
-            created_at: self.created_at,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.statuses_count,
-            note: self.note,
-            url: self.url,
-            avatar: self.avatar,
-            avatar_static: self.avatar_static,
-            header: self.header,
-            header_static: self.header_static,
-            emojis: self.emojis.into_iter().map(|e| e.into()).collect(),
-            fields: self.fields.into_iter().map(|f| f.into()).collect(),
-            bot: self.bot,
+            created_at: val.created_at,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.statuses_count,
+            note: val.note,
+            url: val.url,
+            avatar: val.avatar,
+            avatar_static: val.avatar_static,
+            header: val.header,
+            header_static: val.header_static,
+            emojis: val.emojis.into_iter().map(|e| e.into()).collect(),
+            fields: val.fields.into_iter().map(|f| f.into()).collect(),
+            bot: val.bot,
             source: None,
             role: None,
             mute_expires_at: None,

--- a/src/firefish/entities/announcement.rs
+++ b/src/firefish/entities/announcement.rs
@@ -16,18 +16,18 @@ pub struct Announcement {
     // is_good_news: bool,
 }
 
-impl Into<MegalodonEntities::Announcement> for Announcement {
-    fn into(self) -> MegalodonEntities::Announcement {
+impl From<Announcement> for MegalodonEntities::Announcement {
+    fn from(val: Announcement) -> Self {
         MegalodonEntities::Announcement {
-            id: self.id,
-            content: format!("{}\n{}", self.title, self.text),
+            id: val.id,
+            content: format!("{}\n{}", val.title, val.text),
             starts_at: None,
             ends_at: None,
             published: true,
             all_day: true,
-            published_at: self.created_at,
-            updated_at: self.updated_at,
-            read: self.is_read,
+            published_at: val.created_at,
+            updated_at: val.updated_at,
+            read: val.is_read,
             mentions: [].to_vec(),
             statuses: [].to_vec(),
             tags: [].to_vec(),

--- a/src/firefish/entities/created_note.rs
+++ b/src/firefish/entities/created_note.rs
@@ -9,14 +9,14 @@ pub struct CreatedNote {
     created_note: Note,
 }
 
-impl Into<MegalodonEntities::Status> for CreatedNote {
-    fn into(self) -> MegalodonEntities::Status {
-        self.created_note.into()
+impl From<CreatedNote> for MegalodonEntities::Status {
+    fn from(val: CreatedNote) -> Self {
+        val.created_note.into()
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for CreatedNote {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::Status(self.into())
+impl From<CreatedNote> for megalodon::PostStatusOutput {
+    fn from(val: CreatedNote) -> Self {
+        megalodon::PostStatusOutput::Status(val.into())
     }
 }

--- a/src/firefish/entities/emoji.rs
+++ b/src/firefish/entities/emoji.rs
@@ -8,14 +8,14 @@ pub struct Emoji {
     pub(crate) category: Option<String>,
 }
 
-impl Into<MegalodonEntities::Emoji> for Emoji {
-    fn into(self) -> MegalodonEntities::Emoji {
+impl From<Emoji> for MegalodonEntities::Emoji {
+    fn from(val: Emoji) -> Self {
         MegalodonEntities::Emoji {
-            shortcode: self.name,
-            static_url: self.url.clone(),
-            url: self.url,
+            shortcode: val.name,
+            static_url: val.url.clone(),
+            url: val.url,
             visible_in_picker: true,
-            category: self.category,
+            category: val.category,
         }
     }
 }

--- a/src/firefish/entities/field.rs
+++ b/src/firefish/entities/field.rs
@@ -8,13 +8,13 @@ pub struct Field {
     verified: Option<bool>,
 }
 
-impl Into<MegalodonEntities::Field> for Field {
-    fn into(self) -> MegalodonEntities::Field {
+impl From<Field> for MegalodonEntities::Field {
+    fn from(val: Field) -> Self {
         MegalodonEntities::Field {
-            name: self.name,
-            value: self.value,
+            name: val.name,
+            value: val.value,
             verified_at: None,
-            verified: self.verified,
+            verified: val.verified,
         }
     }
 }

--- a/src/firefish/entities/file.rs
+++ b/src/firefish/entities/file.rs
@@ -29,39 +29,30 @@ pub struct Properties {
     // avg_color: String,
 }
 
-impl Into<MegalodonEntities::Attachment> for File {
-    fn into(self) -> MegalodonEntities::Attachment {
+impl From<File> for MegalodonEntities::Attachment {
+    fn from(val: File) -> Self {
         let mut url = "".to_string();
-        if let Some(u) = self.url.clone() {
+        if let Some(u) = val.url.clone() {
             url = u;
         };
 
         let mut attachment_type = MegalodonEntities::attachment::AttachmentType::Unknown;
-        if self.r#type.as_str() == "image/gif" {
+        if val.r#type.as_str() == "image/gif" {
             attachment_type = MegalodonEntities::attachment::AttachmentType::Gifv;
-        } else if Regex::new(r"^image")
-            .unwrap()
-            .is_match(self.r#type.as_str())
-        {
+        } else if Regex::new(r"^image").unwrap().is_match(val.r#type.as_str()) {
             attachment_type = MegalodonEntities::attachment::AttachmentType::Image;
         }
-        if Regex::new(r"^audio")
-            .unwrap()
-            .is_match(self.r#type.as_str())
-        {
+        if Regex::new(r"^audio").unwrap().is_match(val.r#type.as_str()) {
             attachment_type = MegalodonEntities::attachment::AttachmentType::Audio;
         }
-        if Regex::new(r"^video")
-            .unwrap()
-            .is_match(self.r#type.as_str())
-        {
+        if Regex::new(r"^video").unwrap().is_match(val.r#type.as_str()) {
             attachment_type = MegalodonEntities::attachment::AttachmentType::Video;
         }
 
         let meta = MegalodonEntities::attachment::AttachmentMeta {
             original: Some(MegalodonEntities::attachment::MetaSub {
-                width: self.properties.width,
-                height: self.properties.height,
+                width: val.properties.width,
+                height: val.properties.height,
                 size: None,
                 aspect: None,
                 frame_rate: None,
@@ -74,8 +65,8 @@ impl Into<MegalodonEntities::Attachment> for File {
             duration: None,
             fps: None,
             size: None,
-            width: self.properties.width,
-            height: self.properties.height,
+            width: val.properties.width,
+            height: val.properties.height,
             aspect: None,
             audio_encode: None,
             audio_bitrate: None,
@@ -83,21 +74,21 @@ impl Into<MegalodonEntities::Attachment> for File {
         };
 
         MegalodonEntities::Attachment {
-            id: self.id,
+            id: val.id,
             r#type: attachment_type,
             url,
-            remote_url: self.url.clone(),
-            preview_url: self.thumbnail_url,
-            text_url: self.url,
+            remote_url: val.url.clone(),
+            preview_url: val.thumbnail_url,
+            text_url: val.url,
             meta: Some(meta),
-            description: self.comment,
-            blurhash: self.blurhash,
+            description: val.comment,
+            blurhash: val.blurhash,
         }
     }
 }
 
-impl Into<MegalodonEntities::UploadMedia> for File {
-    fn into(self) -> MegalodonEntities::UploadMedia {
-        MegalodonEntities::UploadMedia::Attachment(self.into())
+impl From<File> for MegalodonEntities::UploadMedia {
+    fn from(val: File) -> Self {
+        MegalodonEntities::UploadMedia::Attachment(val.into())
     }
 }

--- a/src/firefish/entities/follow_request.rs
+++ b/src/firefish/entities/follow_request.rs
@@ -11,14 +11,14 @@ pub struct FollowRequest {
     // followee: User,
 }
 
-impl Into<MegalodonEntities::Account> for FollowRequest {
-    fn into(self) -> MegalodonEntities::Account {
-        self.follower.into()
+impl From<FollowRequest> for MegalodonEntities::Account {
+    fn from(val: FollowRequest) -> Self {
+        val.follower.into()
     }
 }
 
-impl Into<megalodon::FollowRequestOutput> for FollowRequest {
-    fn into(self) -> megalodon::FollowRequestOutput {
-        megalodon::FollowRequestOutput::Account(self.into())
+impl From<FollowRequest> for megalodon::FollowRequestOutput {
+    fn from(val: FollowRequest) -> Self {
+        megalodon::FollowRequestOutput::Account(val.into())
     }
 }

--- a/src/firefish/entities/hashtag.rs
+++ b/src/firefish/entities/hashtag.rs
@@ -7,11 +7,11 @@ pub struct Hashtag {
     pub tag: String,
 }
 
-impl Into<MegalodonEntities::Tag> for Hashtag {
-    fn into(self) -> MegalodonEntities::Tag {
+impl From<Hashtag> for MegalodonEntities::Tag {
+    fn from(val: Hashtag) -> Self {
         MegalodonEntities::Tag {
-            name: self.tag.clone(),
-            url: self.tag,
+            name: val.tag.clone(),
+            url: val.tag,
             history: [].to_vec(),
             following: None,
         }

--- a/src/firefish/entities/instance.rs
+++ b/src/firefish/entities/instance.rs
@@ -23,23 +23,23 @@ pub struct Instance {
     pub contact_account: Account,
 }
 
-impl Into<MegalodonEntities::Instance> for Instance {
-    fn into(self) -> MegalodonEntities::Instance {
+impl From<Instance> for MegalodonEntities::Instance {
+    fn from(val: Instance) -> Self {
         MegalodonEntities::Instance {
-            uri: self.uri,
-            title: self.title,
-            description: self.description,
-            email: self.email,
-            version: self.version,
-            thumbnail: self.thumbnail,
-            urls: Some(self.urls.into()),
-            stats: self.stats.into(),
-            languages: self.languages,
-            registrations: self.registrations,
-            approval_required: self.approval_required,
-            invites_enabled: Some(self.invites_enabled),
-            configuration: self.configuration.into(),
-            contact_account: Some(self.contact_account.into()),
+            uri: val.uri,
+            title: val.title,
+            description: val.description,
+            email: val.email,
+            version: val.version,
+            thumbnail: val.thumbnail,
+            urls: Some(val.urls.into()),
+            stats: val.stats.into(),
+            languages: val.languages,
+            registrations: val.registrations,
+            approval_required: val.approval_required,
+            invites_enabled: Some(val.invites_enabled),
+            configuration: val.configuration.into(),
+            contact_account: Some(val.contact_account.into()),
             rules: None,
         }
     }
@@ -50,10 +50,10 @@ pub struct URLs {
     pub streaming_api: String,
 }
 
-impl Into<MegalodonEntities::URLs> for URLs {
-    fn into(self) -> MegalodonEntities::URLs {
+impl From<URLs> for MegalodonEntities::URLs {
+    fn from(val: URLs) -> Self {
         MegalodonEntities::URLs {
-            streaming_api: self.streaming_api,
+            streaming_api: val.streaming_api,
         }
     }
 }
@@ -65,12 +65,12 @@ pub struct Stats {
     pub domain_count: u32,
 }
 
-impl Into<MegalodonEntities::Stats> for Stats {
-    fn into(self) -> MegalodonEntities::Stats {
+impl From<Stats> for MegalodonEntities::Stats {
+    fn from(val: Stats) -> Self {
         MegalodonEntities::Stats {
-            user_count: self.user_count,
-            status_count: self.status_count,
-            domain_count: self.domain_count,
+            user_count: val.user_count,
+            status_count: val.status_count,
+            domain_count: val.domain_count,
         }
     }
 }
@@ -82,11 +82,11 @@ pub struct InstanceConfig {
     pub polls: Polls,
 }
 
-impl Into<MegalodonEntities::instance::InstanceConfig> for InstanceConfig {
-    fn into(self) -> MegalodonEntities::instance::InstanceConfig {
+impl From<InstanceConfig> for MegalodonEntities::instance::InstanceConfig {
+    fn from(val: InstanceConfig) -> Self {
         MegalodonEntities::instance::InstanceConfig {
-            statuses: self.statuses.into(),
-            polls: Some(self.polls.into()),
+            statuses: val.statuses.into(),
+            polls: Some(val.polls.into()),
         }
     }
 }
@@ -98,12 +98,12 @@ pub struct Statuses {
     pub characters_reserved_per_url: u32,
 }
 
-impl Into<MegalodonEntities::instance::Statuses> for Statuses {
-    fn into(self) -> MegalodonEntities::instance::Statuses {
+impl From<Statuses> for MegalodonEntities::instance::Statuses {
+    fn from(val: Statuses) -> Self {
         MegalodonEntities::instance::Statuses {
-            max_characters: self.max_characters,
-            max_media_attachments: Some(self.max_media_attachments),
-            characters_reserved_per_url: Some(self.characters_reserved_per_url),
+            max_characters: val.max_characters,
+            max_media_attachments: Some(val.max_media_attachments),
+            characters_reserved_per_url: Some(val.characters_reserved_per_url),
         }
     }
 }
@@ -126,13 +126,13 @@ pub struct Polls {
     pub max_expiration: u32,
 }
 
-impl Into<MegalodonEntities::instance::Polls> for Polls {
-    fn into(self) -> MegalodonEntities::instance::Polls {
+impl From<Polls> for MegalodonEntities::instance::Polls {
+    fn from(val: Polls) -> Self {
         MegalodonEntities::instance::Polls {
-            max_options: self.max_options,
-            max_characters_per_option: self.max_characters_per_option,
-            min_expiration: self.min_expiration,
-            max_expiration: self.max_expiration,
+            max_options: val.max_options,
+            max_characters_per_option: val.max_characters_per_option,
+            min_expiration: val.min_expiration,
+            max_expiration: val.max_expiration,
         }
     }
 }

--- a/src/firefish/entities/list.rs
+++ b/src/firefish/entities/list.rs
@@ -10,11 +10,11 @@ pub struct List {
     pub user_ids: Option<Vec<String>>,
 }
 
-impl Into<MegalodonEntities::List> for List {
-    fn into(self) -> MegalodonEntities::List {
+impl From<List> for MegalodonEntities::List {
+    fn from(val: List) -> Self {
         MegalodonEntities::List {
-            id: self.id,
-            title: self.name,
+            id: val.id,
+            title: val.name,
             replies_policy: None,
         }
     }

--- a/src/firefish/entities/note.rs
+++ b/src/firefish/entities/note.rs
@@ -84,9 +84,9 @@ impl From<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
     }
 }
 
-impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
-    fn into(self) -> MegalodonEntities::status::StatusVisibility {
-        match self {
+impl From<StatusVisibility> for MegalodonEntities::status::StatusVisibility {
+    fn from(val: StatusVisibility) -> Self {
+        match val {
             StatusVisibility::Public => MegalodonEntities::status::StatusVisibility::Public,
             StatusVisibility::Home => MegalodonEntities::status::StatusVisibility::Unlisted,
             StatusVisibility::Followers => MegalodonEntities::status::StatusVisibility::Private,
@@ -110,33 +110,33 @@ fn convert_html(plain: String) -> String {
         .to_string()
 }
 
-impl Into<MegalodonEntities::Status> for Note {
-    fn into(self) -> MegalodonEntities::Status {
+impl From<Note> for MegalodonEntities::Status {
+    fn from(val: Note) -> Self {
         let mut uri = "".to_string();
-        if let Some(u) = self.uri.clone() {
+        if let Some(u) = val.uri.clone() {
             uri = u;
         }
         let mut reblog_status: Option<Box<MegalodonEntities::Status>> = None;
         let mut quoted = false;
-        if let Some(renote) = self.renote {
+        if let Some(renote) = val.renote {
             let rs: Note = *renote;
             reblog_status = Some(Box::new(rs.into()));
-            if let Some(_) = self.text.clone() {
+            if let Some(_) = val.text.clone() {
                 quoted = true;
             }
         }
         let mut content = "".to_string();
-        if let Some(text) = self.text.clone() {
+        if let Some(text) = val.text.clone() {
             content = convert_html(text);
         }
 
         let mut spoiler_text = "".to_string();
-        if let Some(cw) = self.cw {
+        if let Some(cw) = val.cw {
             spoiler_text = cw;
         }
 
         let mut tags: Vec<MegalodonEntities::status::Tag> = [].to_vec();
-        if let Some(hashtags) = self.tags {
+        if let Some(hashtags) = val.tags {
             tags = hashtags
                 .into_iter()
                 .map(|t| MegalodonEntities::status::Tag {
@@ -146,48 +146,48 @@ impl Into<MegalodonEntities::Status> for Note {
                 .collect();
         }
         let emoji_reactions = Some(map_reaction(
-            self.emojis.clone().unwrap_or_default(),
-            self.reactions,
-            self.my_reaction.clone(),
+            val.emojis.clone().unwrap_or_default(),
+            val.reactions,
+            val.my_reaction.clone(),
         ));
 
         MegalodonEntities::Status {
-            id: self.id,
+            id: val.id,
             uri: uri.clone(),
-            url: self.uri,
-            account: self.user.into(),
-            in_reply_to_id: self.reply_id,
+            url: val.uri,
+            account: val.user.into(),
+            in_reply_to_id: val.reply_id,
             in_reply_to_account_id: None,
             reblog: reblog_status,
             content,
-            plain_content: self.text,
-            created_at: self.created_at,
+            plain_content: val.text,
+            created_at: val.created_at,
             edited_at: None,
-            emojis: self.emojis.map_or([].to_vec(), |o| {
+            emojis: val.emojis.map_or([].to_vec(), |o| {
                 o.into_iter()
                     .filter(|e| !e.name.contains("@"))
                     .map(|e| e.into())
                     .collect()
             }),
-            replies_count: self.replies_count,
-            reblogs_count: self.renote_count,
+            replies_count: val.replies_count,
+            reblogs_count: val.renote_count,
             favourites_count: 0,
             reblogged: None,
-            favourited: Some(self.my_reaction.is_some()),
+            favourited: Some(val.my_reaction.is_some()),
             muted: None,
-            sensitive: self
+            sensitive: val
                 .files
                 .as_ref()
                 .map_or(false, |f| f.iter().any(|f| f.is_sensitive)),
             spoiler_text,
-            visibility: self.visibility.into(),
-            media_attachments: self
+            visibility: val.visibility.into(),
+            media_attachments: val
                 .files
                 .map_or([].to_vec(), |f| f.into_iter().map(|f| f.into()).collect()),
             mentions: [].to_vec(),
             tags,
             card: None,
-            poll: self.poll.map(|p| p.into()),
+            poll: val.poll.map(|p| p.into()),
             application: None,
             language: None,
             pinned: None,
@@ -198,9 +198,9 @@ impl Into<MegalodonEntities::Status> for Note {
     }
 }
 
-impl Into<MegalodonEntities::StatusSource> for Note {
-    fn into(self) -> MegalodonEntities::StatusSource {
-        let Self {id, text, cw, ..} = self;
+impl From<Note> for MegalodonEntities::StatusSource {
+    fn from(val: Note) -> Self {
+        let Note { id, text, cw, .. } = val;
         MegalodonEntities::StatusSource {
             id,
             text: text.unwrap_or_default(),
@@ -209,13 +209,13 @@ impl Into<MegalodonEntities::StatusSource> for Note {
     }
 }
 
-impl Into<MegalodonEntities::Conversation> for Note {
-    fn into(self) -> MegalodonEntities::Conversation {
-        let accounts: Vec<MegalodonEntities::Account> = [self.user.clone().into()].to_vec();
+impl From<Note> for MegalodonEntities::Conversation {
+    fn from(val: Note) -> Self {
+        let accounts: Vec<MegalodonEntities::Account> = [val.user.clone().into()].to_vec();
         MegalodonEntities::Conversation {
-            id: self.id.clone(),
+            id: val.id.clone(),
             accounts,
-            last_status: Some(self.into()),
+            last_status: Some(val.into()),
             unread: false,
         }
     }

--- a/src/firefish/entities/notification.rs
+++ b/src/firefish/entities/notification.rs
@@ -97,9 +97,9 @@ impl From<MegalodonEntities::notification::NotificationType> for NotificationTyp
     }
 }
 
-impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
-    fn into(self) -> MegalodonEntities::notification::NotificationType {
-        match self {
+impl From<NotificationType> for MegalodonEntities::notification::NotificationType {
+    fn from(val: NotificationType) -> Self {
+        match val {
             NotificationType::Follow => MegalodonEntities::notification::NotificationType::Follow,
             NotificationType::Mention => MegalodonEntities::notification::NotificationType::Mention,
             NotificationType::Reply => MegalodonEntities::notification::NotificationType::Mention,
@@ -129,14 +129,14 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
     }
 }
 
-impl Into<MegalodonEntities::Notification> for Notification {
-    fn into(self) -> MegalodonEntities::Notification {
-        let emojis = if let Some(note) = &self.note {
+impl From<Notification> for MegalodonEntities::Notification {
+    fn from(val: Notification) -> Self {
+        let emojis = if let Some(note) = &val.note {
             note.clone().emojis.unwrap_or_default()
         } else {
             [].to_vec()
         };
-        let reactions = if let Some(reaction) = self.reaction {
+        let reactions = if let Some(reaction) = val.reaction {
             map_reaction(emojis, HashMap::<String, u32>::from([(reaction, 1)]), None)
         } else {
             [].to_vec()
@@ -147,13 +147,13 @@ impl Into<MegalodonEntities::Notification> for Notification {
             None
         };
         MegalodonEntities::Notification {
-            account: self.user.map(|u| u.into()),
-            created_at: self.created_at,
-            id: self.id,
-            status: self.note.map(|n| n.into()),
+            account: val.user.map(|u| u.into()),
+            created_at: val.created_at,
+            id: val.id,
+            status: val.note.map(|n| n.into()),
             reaction,
             target: None,
-            r#type: self.r#type.into(),
+            r#type: val.r#type.into(),
         }
     }
 }

--- a/src/firefish/entities/poll.rs
+++ b/src/firefish/entities/poll.rs
@@ -19,36 +19,36 @@ pub struct Choice {
     is_voted: Option<bool>,
 }
 
-impl Into<MegalodonEntities::PollOption> for Choice {
-    fn into(self) -> MegalodonEntities::PollOption {
+impl From<Choice> for MegalodonEntities::PollOption {
+    fn from(val: Choice) -> Self {
         MegalodonEntities::PollOption {
-            title: self.text,
-            votes_count: Some(self.votes),
+            title: val.text,
+            votes_count: Some(val.votes),
         }
     }
 }
 
-impl Into<MegalodonEntities::Poll> for Poll {
-    fn into(self) -> MegalodonEntities::Poll {
+impl From<Poll> for MegalodonEntities::Poll {
+    fn from(val: Poll) -> Self {
         let mut expired = false;
-        if let Some(at) = self.expires_at {
+        if let Some(at) = val.expires_at {
             let now = Utc::now();
             let diff = now - at;
             if diff.num_seconds() > 0 {
                 expired = true;
             }
         }
-        let votes_count: u32 = self.choices.iter().map(|c| c.votes).sum();
+        let votes_count: u32 = val.choices.iter().map(|c| c.votes).sum();
 
         MegalodonEntities::Poll {
             id: "".to_string(),
-            expires_at: self.expires_at,
+            expires_at: val.expires_at,
             expired,
-            multiple: self.multiple,
+            multiple: val.multiple,
             votes_count,
             voters_count: None,
-            options: self.choices.clone().into_iter().map(|c| c.into()).collect(),
-            voted: Some(self.choices.iter().any(|c| {
+            options: val.choices.clone().into_iter().map(|c| c.into()).collect(),
+            voted: Some(val.choices.iter().any(|c| {
                 if let Some(voted) = c.is_voted {
                     voted
                 } else {

--- a/src/firefish/entities/relation.rs
+++ b/src/firefish/entities/relation.rs
@@ -16,19 +16,19 @@ pub struct Relation {
     is_renote_muted: bool,
 }
 
-impl Into<MegalodonEntities::Relationship> for Relation {
-    fn into(self) -> MegalodonEntities::Relationship {
+impl From<Relation> for MegalodonEntities::Relationship {
+    fn from(val: Relation) -> Self {
         MegalodonEntities::Relationship {
-            id: self.id,
-            following: self.is_following,
-            followed_by: self.is_followed,
-            blocking: self.is_blocking,
-            blocked_by: self.is_blocked,
-            muting: self.is_muted,
+            id: val.id,
+            following: val.is_following,
+            followed_by: val.is_followed,
+            blocking: val.is_blocking,
+            blocked_by: val.is_blocked,
+            muting: val.is_muted,
             muting_notifications: false,
-            requested: self.has_pending_follow_request_from_you,
+            requested: val.has_pending_follow_request_from_you,
             domain_blocking: false,
-            showing_reblogs: self.is_renote_muted,
+            showing_reblogs: val.is_renote_muted,
             endorsed: false,
             notifying: false,
             note: None,

--- a/src/firefish/entities/stats.rs
+++ b/src/firefish/entities/stats.rs
@@ -11,12 +11,12 @@ pub struct Stats {
     instances: u32,
 }
 
-impl Into<MegalodonEntities::Stats> for Stats {
-    fn into(self) -> MegalodonEntities::Stats {
+impl From<Stats> for MegalodonEntities::Stats {
+    fn from(val: Stats) -> Self {
         MegalodonEntities::Stats {
-            user_count: self.users_count,
-            status_count: self.notes_count,
-            domain_count: self.instances,
+            user_count: val.users_count,
+            status_count: val.notes_count,
+            domain_count: val.instances,
         }
     }
 }

--- a/src/firefish/entities/user.rs
+++ b/src/firefish/entities/user.rs
@@ -24,38 +24,38 @@ pub struct User {
     pub online_status: Option<String>,
 }
 
-impl Into<MegalodonEntities::Account> for User {
-    fn into(self) -> MegalodonEntities::Account {
-        let mut acct = self.username.clone();
-        if let Some(host) = self.host {
-            acct = format!("{}@{}", self.username, host);
+impl From<User> for MegalodonEntities::Account {
+    fn from(val: User) -> Self {
+        let mut acct = val.username.clone();
+        if let Some(host) = val.host {
+            acct = format!("{}@{}", val.username, host);
         }
         let mut display_name = "".to_string();
-        if let Some(name) = self.name {
+        if let Some(name) = val.name {
             display_name = name;
         }
         let mut avatar = "".to_string();
-        if let Some(avatar_url) = self.avatar_url {
+        if let Some(avatar_url) = val.avatar_url {
             avatar = avatar_url;
         }
         let mut avatar_static = "".to_string();
-        if let Some(avatar_color) = self.avatar_color {
+        if let Some(avatar_color) = val.avatar_color {
             avatar_static = avatar_color;
         }
         let mut bot = false;
-        if let Some(is_bot) = self.is_bot {
+        if let Some(is_bot) = val.is_bot {
             bot = is_bot;
         }
 
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
+            id: val.id,
+            username: val.username,
             acct: acct.clone(),
             display_name,
             locked: false,
             discoverable: None,
             group: None,
-            noindex: self.is_indexable,
+            noindex: val.is_indexable,
             moved: None,
             suspended: None,
             limited: None,
@@ -69,7 +69,7 @@ impl Into<MegalodonEntities::Account> for User {
             avatar_static,
             header: "".to_string(),
             header_static: "".to_string(),
-            emojis: self.emojis.into_iter().map(|e| e.into()).collect(),
+            emojis: val.emojis.into_iter().map(|e| e.into()).collect(),
             fields: [].to_vec(),
             bot,
             source: None,

--- a/src/firefish/entities/user_detail.rs
+++ b/src/firefish/entities/user_detail.rs
@@ -88,73 +88,73 @@ pub struct UserDetail {
     // email_notification_types: Option<Vec<String>>,
 }
 
-impl Into<MegalodonEntities::Account> for UserDetail {
-    fn into(self) -> MegalodonEntities::Account {
-        let mut acct = self.username.clone();
-        if let Some(host) = self.host {
-            acct = format!("{}@{}", self.username, host);
+impl From<UserDetail> for MegalodonEntities::Account {
+    fn from(val: UserDetail) -> Self {
+        let mut acct = val.username.clone();
+        if let Some(host) = val.host {
+            acct = format!("{}@{}", val.username, host);
         }
         let mut display_name = "".to_string();
-        if let Some(name) = self.name {
+        if let Some(name) = val.name {
             display_name = name;
         }
         let mut note = "".to_string();
-        if let Some(description) = self.description {
+        if let Some(description) = val.description {
             note = description;
         }
         let mut avatar = "".to_string();
-        if let Some(avatar_url) = self.avatar_url {
+        if let Some(avatar_url) = val.avatar_url {
             avatar = avatar_url;
         }
         let mut avatar_static = "".to_string();
-        if let Some(avatar_color) = self.avatar_color {
+        if let Some(avatar_color) = val.avatar_color {
             avatar_static = avatar_color;
         }
         let mut header = "".to_string();
-        if let Some(banner_url) = self.banner_url {
+        if let Some(banner_url) = val.banner_url {
             header = banner_url;
         }
         let mut header_static = "".to_string();
-        if let Some(banner_color) = self.banner_color {
+        if let Some(banner_color) = val.banner_color {
             header_static = banner_color;
         }
         let mut bot = false;
-        if let Some(is_bot) = self.is_bot {
+        if let Some(is_bot) = val.is_bot {
             bot = is_bot;
         }
 
         let source = MegalodonEntities::Source {
             privacy: None,
-            sensitive: self.always_mark_nsfw,
-            language: self.lang,
+            sensitive: val.always_mark_nsfw,
+            language: val.lang,
             note: note.clone(),
             fields: None,
         };
 
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
+            id: val.id,
+            username: val.username,
             acct: acct.clone(),
             display_name,
-            locked: self.is_locked,
+            locked: val.is_locked,
             discoverable: None,
             group: None,
-            noindex: self.is_indexable,
-            suspended: Some(self.is_suspended),
-            limited: Some(self.is_silenced),
-            created_at: self.created_at,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.notes_count,
+            noindex: val.is_indexable,
+            suspended: Some(val.is_suspended),
+            limited: Some(val.is_silenced),
+            created_at: val.created_at,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.notes_count,
             note,
             url: acct,
             avatar,
             avatar_static,
             header,
             header_static,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
             moved: None,
-            fields: self.fields.into_iter().map(|j| j.into()).collect(),
+            fields: val.fields.into_iter().map(|j| j.into()).collect(),
             bot,
             source: Some(source),
             role: None,

--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -329,7 +329,7 @@ impl megalodon::Megalodon for Firefish {
             .post::<oauth::AppDataFromServer>("/api/app/create", &params, None)
             .await?;
         if let Some(_) = res.json.secret {
-            Ok(MegalodonOAuth::AppData::from(res.json.into()))
+            Ok(res.json.into())
         } else {
             Err(Error::new_own(
                 "secret does not exist".to_string(),
@@ -355,7 +355,7 @@ impl megalodon::Megalodon for Firefish {
             .client
             .post::<oauth::TokenDataFromServer>("/api/auth/session/userKey", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn refresh_access_token(
@@ -1318,7 +1318,10 @@ impl megalodon::Megalodon for Firefish {
         ))
     }
 
-    async fn get_status_source(&self, id: String) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
+    async fn get_status_source(
+        &self,
+        id: String,
+    ) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
         let params = HashMap::<&str, Value>::from([("noteId", Value::String(id))]);
         let res = self
             .client

--- a/src/firefish/oauth.rs
+++ b/src/firefish/oauth.rs
@@ -13,15 +13,15 @@ pub struct AppDataFromServer {
     pub is_authorized: Option<bool>,
 }
 
-impl Into<oauth::AppData> for AppDataFromServer {
-    fn into(self) -> oauth::AppData {
+impl From<AppDataFromServer> for oauth::AppData {
+    fn from(val: AppDataFromServer) -> Self {
         oauth::AppData::new(
-            self.id,
-            self.name,
+            val.id,
+            val.name,
             None,
-            self.callback_url,
+            val.callback_url,
             "".to_string(),
-            self.secret.unwrap(),
+            val.secret.unwrap(),
         )
     }
 }
@@ -33,10 +33,10 @@ pub struct TokenDataFromServer {
     access_token: String,
 }
 
-impl Into<oauth::TokenData> for TokenDataFromServer {
-    fn into(self) -> oauth::TokenData {
+impl From<TokenDataFromServer> for oauth::TokenData {
+    fn from(val: TokenDataFromServer) -> Self {
         oauth::TokenData::new(
-            self.access_token,
+            val.access_token,
             "Firefish".to_string(),
             None,
             None,

--- a/src/friendica/entities/account.rs
+++ b/src/friendica/entities/account.rs
@@ -68,39 +68,39 @@ impl From<MegalodonEntities::Account> for Account {
     }
 }
 
-impl Into<MegalodonEntities::Account> for Account {
-    fn into(self) -> MegalodonEntities::Account {
+impl From<Account> for MegalodonEntities::Account {
+    fn from(val: Account) -> Self {
         let mut moved_account: Option<Box<MegalodonEntities::Account>> = None;
-        if let Some(moved) = self.moved {
+        if let Some(moved) = val.moved {
             let ma: Account = *moved;
             moved_account = Some(Box::new(ma.into()));
         }
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
-            acct: self.acct,
-            display_name: self.display_name,
-            locked: self.locked,
-            discoverable: self.discoverable,
-            group: Some(self.group),
+            id: val.id,
+            username: val.username,
+            acct: val.acct,
+            display_name: val.display_name,
+            locked: val.locked,
+            discoverable: val.discoverable,
+            group: Some(val.group),
             noindex: None,
             suspended: None,
             limited: None,
-            created_at: self.created_at,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.statuses_count,
-            note: self.note,
-            url: self.url,
-            avatar: self.avatar,
-            avatar_static: self.avatar_static,
-            header: self.header,
-            header_static: self.header_static,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            created_at: val.created_at,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.statuses_count,
+            note: val.note,
+            url: val.url,
+            avatar: val.avatar,
+            avatar_static: val.avatar_static,
+            header: val.header,
+            header_static: val.header_static,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
             moved: moved_account,
-            fields: self.fields.into_iter().map(|j| j.into()).collect(),
-            bot: self.bot,
-            source: self.source.map(|i| i.into()),
+            fields: val.fields.into_iter().map(|j| j.into()).collect(),
+            bot: val.bot,
+            source: val.source.map(|i| i.into()),
             role: None,
             mute_expires_at: None,
         }

--- a/src/friendica/entities/activity.rs
+++ b/src/friendica/entities/activity.rs
@@ -9,13 +9,13 @@ pub struct Activity {
     registrations: String,
 }
 
-impl Into<MegalodonEntities::Activity> for Activity {
-    fn into(self) -> MegalodonEntities::Activity {
+impl From<Activity> for MegalodonEntities::Activity {
+    fn from(val: Activity) -> Self {
         MegalodonEntities::Activity {
-            week: self.week,
-            statuses: self.statuses,
-            logins: self.logins,
-            registrations: self.registrations,
+            week: val.week,
+            statuses: val.statuses,
+            logins: val.logins,
+            registrations: val.registrations,
         }
     }
 }

--- a/src/friendica/entities/application.rs
+++ b/src/friendica/entities/application.rs
@@ -8,12 +8,12 @@ pub struct Application {
     vapid_key: Option<String>,
 }
 
-impl Into<MegalodonEntities::Application> for Application {
-    fn into(self) -> MegalodonEntities::Application {
+impl From<Application> for MegalodonEntities::Application {
+    fn from(val: Application) -> Self {
         MegalodonEntities::Application {
-            name: self.name,
-            website: self.website,
-            vapid_key: self.vapid_key,
+            name: val.name,
+            website: val.website,
+            vapid_key: val.vapid_key,
         }
     }
 }

--- a/src/friendica/entities/attachment.rs
+++ b/src/friendica/entities/attachment.rs
@@ -63,9 +63,9 @@ pub enum AttachmentType {
     Unknown,
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentType {
-        match self {
+impl From<AttachmentType> for MegalodonEntities::attachment::AttachmentType {
+    fn from(val: AttachmentType) -> Self {
+        match val {
             AttachmentType::Image => MegalodonEntities::attachment::AttachmentType::Image,
             AttachmentType::Gifv => MegalodonEntities::attachment::AttachmentType::Gifv,
             AttachmentType::Video => MegalodonEntities::attachment::AttachmentType::Video,
@@ -75,91 +75,88 @@ impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
     }
 }
 
-impl Into<MegalodonEntities::Attachment> for Attachment {
-    fn into(self) -> MegalodonEntities::Attachment {
+impl From<Attachment> for MegalodonEntities::Attachment {
+    fn from(val: Attachment) -> Self {
         MegalodonEntities::Attachment {
-            id: self.id,
-            r#type: self.r#type.into(),
-            url: self.url.unwrap(),
-            remote_url: self.remote_url,
-            preview_url: self.preview_url,
-            text_url: self.text_url,
-            meta: self.meta.map(|i| i.into()),
-            description: self.description,
-            blurhash: self.blurhash,
+            id: val.id,
+            r#type: val.r#type.into(),
+            url: val.url.unwrap(),
+            remote_url: val.remote_url,
+            preview_url: val.preview_url,
+            text_url: val.text_url,
+            meta: val.meta.map(|i| i.into()),
+            description: val.description,
+            blurhash: val.blurhash,
         }
     }
 }
 
-impl Into<MegalodonEntities::UploadMedia> for Attachment {
-    fn into(self) -> MegalodonEntities::UploadMedia {
-        if let Some(url) = self.url {
+impl From<Attachment> for MegalodonEntities::UploadMedia {
+    fn from(val: Attachment) -> Self {
+        if let Some(url) = val.url {
             MegalodonEntities::UploadMedia::Attachment(MegalodonEntities::Attachment {
-                id: self.id,
-                r#type: self.r#type.into(),
+                id: val.id,
+                r#type: val.r#type.into(),
                 url,
-                remote_url: self.remote_url,
-                preview_url: self.preview_url,
-                text_url: self.text_url,
-                meta: self.meta.map(|i| i.into()),
-                description: self.description,
-                blurhash: self.blurhash,
+                remote_url: val.remote_url,
+                preview_url: val.preview_url,
+                text_url: val.text_url,
+                meta: val.meta.map(|i| i.into()),
+                description: val.description,
+                blurhash: val.blurhash,
             })
         } else {
             MegalodonEntities::UploadMedia::AsyncAttachment(MegalodonEntities::AsyncAttachment {
-                id: self.id,
-                r#type: self.r#type.into(),
+                id: val.id,
+                r#type: val.r#type.into(),
                 url: None,
-                remote_url: self.remote_url,
-                preview_url: self.preview_url,
-                text_url: self.text_url,
-                meta: self.meta.map(|i| i.into()),
-                description: self.description,
-                blurhash: self.blurhash,
+                remote_url: val.remote_url,
+                preview_url: val.preview_url,
+                text_url: val.text_url,
+                meta: val.meta.map(|i| i.into()),
+                description: val.description,
+                blurhash: val.blurhash,
             })
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentMeta> for AttachmentMeta {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentMeta {
+impl From<AttachmentMeta> for MegalodonEntities::attachment::AttachmentMeta {
+    fn from(val: AttachmentMeta) -> Self {
         MegalodonEntities::attachment::AttachmentMeta {
-            original: self.original.map(|i| i.into()),
-            small: self.small.map(|i| i.into()),
-            focus: self.focus.map(|i| i.into()),
-            length: self.length,
-            duration: self.duration,
-            fps: self.fps,
-            size: self.size,
-            width: self.width,
-            height: self.height,
-            aspect: self.aspect,
-            audio_encode: self.audio_encode,
-            audio_bitrate: self.audio_bitrate,
-            audio_channel: self.audio_channel,
+            original: val.original.map(|i| i.into()),
+            small: val.small.map(|i| i.into()),
+            focus: val.focus.map(|i| i.into()),
+            length: val.length,
+            duration: val.duration,
+            fps: val.fps,
+            size: val.size,
+            width: val.width,
+            height: val.height,
+            aspect: val.aspect,
+            audio_encode: val.audio_encode,
+            audio_bitrate: val.audio_bitrate,
+            audio_channel: val.audio_channel,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::MetaSub> for MetaSub {
-    fn into(self) -> MegalodonEntities::attachment::MetaSub {
+impl From<MetaSub> for MegalodonEntities::attachment::MetaSub {
+    fn from(val: MetaSub) -> Self {
         MegalodonEntities::attachment::MetaSub {
-            width: self.width,
-            height: self.height,
-            size: self.size,
-            aspect: self.aspect,
-            frame_rate: self.frame_rate,
-            duration: self.duration,
-            bitrate: self.bitrate,
+            width: val.width,
+            height: val.height,
+            size: val.size,
+            aspect: val.aspect,
+            frame_rate: val.frame_rate,
+            duration: val.duration,
+            bitrate: val.bitrate,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::Focus> for Focus {
-    fn into(self) -> MegalodonEntities::attachment::Focus {
-        MegalodonEntities::attachment::Focus {
-            x: self.x,
-            y: self.y,
-        }
+impl From<Focus> for MegalodonEntities::attachment::Focus {
+    fn from(val: Focus) -> Self {
+        MegalodonEntities::attachment::Focus { x: val.x, y: val.y }
     }
 }

--- a/src/friendica/entities/card.rs
+++ b/src/friendica/entities/card.rs
@@ -27,9 +27,9 @@ pub enum CardType {
     Rich,
 }
 
-impl Into<MegalodonEntities::card::CardType> for CardType {
-    fn into(self) -> MegalodonEntities::card::CardType {
-        match self {
+impl From<CardType> for MegalodonEntities::card::CardType {
+    fn from(val: CardType) -> Self {
+        match val {
             CardType::Link => MegalodonEntities::card::CardType::Link,
             CardType::Photo => MegalodonEntities::card::CardType::Photo,
             CardType::Video => MegalodonEntities::card::CardType::Video,
@@ -38,23 +38,23 @@ impl Into<MegalodonEntities::card::CardType> for CardType {
     }
 }
 
-impl Into<MegalodonEntities::Card> for Card {
-    fn into(self) -> MegalodonEntities::Card {
+impl From<Card> for MegalodonEntities::Card {
+    fn from(val: Card) -> Self {
         MegalodonEntities::Card {
-            url: self.url,
-            title: self.title,
-            description: self.description,
-            r#type: self.r#type.into(),
-            image: self.image,
-            author_name: Some(self.author_name),
-            author_url: Some(self.author_url),
-            provider_name: self.provider_name,
-            provider_url: self.provider_url,
-            html: Some(self.html),
-            width: Some(self.width),
-            height: Some(self.height),
+            url: val.url,
+            title: val.title,
+            description: val.description,
+            r#type: val.r#type.into(),
+            image: val.image,
+            author_name: Some(val.author_name),
+            author_url: Some(val.author_url),
+            provider_name: val.provider_name,
+            provider_url: val.provider_url,
+            html: Some(val.html),
+            width: Some(val.width),
+            height: Some(val.height),
             embed_url: None,
-            blurhash: self.blurhash,
+            blurhash: val.blurhash,
         }
     }
 }

--- a/src/friendica/entities/context.rs
+++ b/src/friendica/entities/context.rs
@@ -8,11 +8,11 @@ pub struct Context {
     descendants: Vec<Status>,
 }
 
-impl Into<MegalodonEntities::Context> for Context {
-    fn into(self) -> MegalodonEntities::Context {
+impl From<Context> for MegalodonEntities::Context {
+    fn from(val: Context) -> Self {
         MegalodonEntities::Context {
-            ancestors: self.ancestors.into_iter().map(|i| i.into()).collect(),
-            descendants: self.descendants.into_iter().map(|i| i.into()).collect(),
+            ancestors: val.ancestors.into_iter().map(|i| i.into()).collect(),
+            descendants: val.descendants.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/friendica/entities/conversation.rs
+++ b/src/friendica/entities/conversation.rs
@@ -10,13 +10,13 @@ pub struct Conversation {
     unread: bool,
 }
 
-impl Into<MegalodonEntities::Conversation> for Conversation {
-    fn into(self) -> MegalodonEntities::Conversation {
+impl From<Conversation> for MegalodonEntities::Conversation {
+    fn from(val: Conversation) -> Self {
         MegalodonEntities::Conversation {
-            id: self.id,
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            last_status: self.last_status.map(|i| i.into()),
-            unread: self.unread,
+            id: val.id,
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            last_status: val.last_status.map(|i| i.into()),
+            unread: val.unread,
         }
     }
 }

--- a/src/friendica/entities/emoji.rs
+++ b/src/friendica/entities/emoji.rs
@@ -20,13 +20,13 @@ impl From<MegalodonEntities::Emoji> for Emoji {
     }
 }
 
-impl Into<MegalodonEntities::Emoji> for Emoji {
-    fn into(self) -> MegalodonEntities::Emoji {
+impl From<Emoji> for MegalodonEntities::Emoji {
+    fn from(val: Emoji) -> Self {
         MegalodonEntities::Emoji {
-            shortcode: self.shortcode,
-            static_url: self.static_url,
-            url: self.url,
-            visible_in_picker: self.visible_in_picker,
+            shortcode: val.shortcode,
+            static_url: val.static_url,
+            url: val.url,
+            visible_in_picker: val.visible_in_picker,
             category: None,
         }
     }

--- a/src/friendica/entities/featured_tag.rs
+++ b/src/friendica/entities/featured_tag.rs
@@ -10,13 +10,13 @@ pub struct FeaturedTag {
     last_status_at: DateTime<Utc>,
 }
 
-impl Into<MegalodonEntities::FeaturedTag> for FeaturedTag {
-    fn into(self) -> MegalodonEntities::FeaturedTag {
+impl From<FeaturedTag> for MegalodonEntities::FeaturedTag {
+    fn from(val: FeaturedTag) -> Self {
         MegalodonEntities::FeaturedTag {
-            id: self.id,
-            name: self.name,
-            statuses_count: self.statuses_count,
-            last_status_at: self.last_status_at,
+            id: val.id,
+            name: val.name,
+            statuses_count: val.statuses_count,
+            last_status_at: val.last_status_at,
         }
     }
 }

--- a/src/friendica/entities/field.rs
+++ b/src/friendica/entities/field.rs
@@ -19,12 +19,12 @@ impl From<MegalodonEntities::Field> for Field {
     }
 }
 
-impl Into<MegalodonEntities::Field> for Field {
-    fn into(self) -> MegalodonEntities::Field {
+impl From<Field> for MegalodonEntities::Field {
+    fn from(val: Field) -> Self {
         MegalodonEntities::Field {
-            name: self.name,
-            value: self.value,
-            verified_at: self.verified_at,
+            name: val.name,
+            value: val.value,
+            verified_at: val.verified_at,
             verified: None,
         }
     }

--- a/src/friendica/entities/filter.rs
+++ b/src/friendica/entities/filter.rs
@@ -21,9 +21,9 @@ pub enum FilterContext {
     Thread,
 }
 
-impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
-    fn into(self) -> MegalodonEntities::filter::FilterContext {
-        match self {
+impl From<FilterContext> for MegalodonEntities::filter::FilterContext {
+    fn from(val: FilterContext) -> Self {
+        match val {
             FilterContext::Home => MegalodonEntities::filter::FilterContext::Home,
             FilterContext::Notifications => MegalodonEntities::filter::FilterContext::Notifications,
             FilterContext::Public => MegalodonEntities::filter::FilterContext::Public,
@@ -32,15 +32,15 @@ impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
     }
 }
 
-impl Into<MegalodonEntities::Filter> for Filter {
-    fn into(self) -> MegalodonEntities::Filter {
+impl From<Filter> for MegalodonEntities::Filter {
+    fn from(val: Filter) -> Self {
         MegalodonEntities::Filter {
-            id: self.id,
-            phrase: self.phrase,
-            context: self.context.into_iter().map(|i| i.into()).collect(),
-            expires_at: self.expires_at,
-            irreversible: self.irreversible,
-            whole_word: self.whole_word,
+            id: val.id,
+            phrase: val.phrase,
+            context: val.context.into_iter().map(|i| i.into()).collect(),
+            expires_at: val.expires_at,
+            irreversible: val.irreversible,
+            whole_word: val.whole_word,
         }
     }
 }

--- a/src/friendica/entities/follow_request.rs
+++ b/src/friendica/entities/follow_request.rs
@@ -54,35 +54,35 @@ impl From<MegalodonEntities::FollowRequest> for FollowRequest {
     }
 }
 
-impl Into<MegalodonEntities::FollowRequest> for FollowRequest {
-    fn into(self) -> MegalodonEntities::FollowRequest {
+impl From<FollowRequest> for MegalodonEntities::FollowRequest {
+    fn from(val: FollowRequest) -> Self {
         MegalodonEntities::FollowRequest {
-            id: self.id,
-            username: self.username,
-            acct: self.acct,
-            display_name: self.display_name,
-            locked: self.locked,
-            bot: self.bot,
-            discoverable: self.discoverable,
-            group: self.group,
-            created_at: self.created_at,
-            note: self.note,
-            url: self.url,
-            avatar: self.avatar,
-            avatar_static: self.avatar_static,
-            header: self.header,
-            header_static: self.header_static,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.statuses_count,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            fields: self.fields.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            username: val.username,
+            acct: val.acct,
+            display_name: val.display_name,
+            locked: val.locked,
+            bot: val.bot,
+            discoverable: val.discoverable,
+            group: val.group,
+            created_at: val.created_at,
+            note: val.note,
+            url: val.url,
+            avatar: val.avatar,
+            avatar_static: val.avatar_static,
+            header: val.header,
+            header_static: val.header_static,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.statuses_count,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            fields: val.fields.into_iter().map(|i| i.into()).collect(),
         }
     }
 }
 
-impl Into<megalodon::FollowRequestOutput> for FollowRequest {
-    fn into(self) -> megalodon::FollowRequestOutput {
-        megalodon::FollowRequestOutput::FollowRequest(self.into())
+impl From<FollowRequest> for megalodon::FollowRequestOutput {
+    fn from(val: FollowRequest) -> Self {
+        megalodon::FollowRequestOutput::FollowRequest(val.into())
     }
 }

--- a/src/friendica/entities/history.rs
+++ b/src/friendica/entities/history.rs
@@ -11,12 +11,12 @@ pub struct History {
     accounts: usize,
 }
 
-impl Into<MegalodonEntities::History> for History {
-    fn into(self) -> MegalodonEntities::History {
+impl From<History> for MegalodonEntities::History {
+    fn from(val: History) -> Self {
         MegalodonEntities::History {
-            day: self.day,
-            uses: self.uses,
-            accounts: self.accounts,
+            day: val.day,
+            uses: val.uses,
+            accounts: val.accounts,
         }
     }
 }

--- a/src/friendica/entities/identity_proof.rs
+++ b/src/friendica/entities/identity_proof.rs
@@ -11,14 +11,14 @@ pub struct IdentityProof {
     profile_url: String,
 }
 
-impl Into<MegalodonEntities::IdentityProof> for IdentityProof {
-    fn into(self) -> MegalodonEntities::IdentityProof {
+impl From<IdentityProof> for MegalodonEntities::IdentityProof {
+    fn from(val: IdentityProof) -> Self {
         MegalodonEntities::IdentityProof {
-            provider: self.provider,
-            provider_username: self.provider_username,
-            updated_at: self.updated_at,
-            proof_url: self.proof_url,
-            profile_url: self.profile_url,
+            provider: val.provider,
+            provider_username: val.provider_username,
+            updated_at: val.updated_at,
+            proof_url: val.proof_url,
+            profile_url: val.profile_url,
         }
     }
 }

--- a/src/friendica/entities/instance.rs
+++ b/src/friendica/entities/instance.rs
@@ -27,40 +27,40 @@ pub struct InstanceRule {
     pub text: String,
 }
 
-impl Into<MegalodonEntities::Instance> for Instance {
-    fn into(self) -> MegalodonEntities::Instance {
+impl From<Instance> for MegalodonEntities::Instance {
+    fn from(val: Instance) -> Self {
         MegalodonEntities::Instance {
-            uri: self.uri,
-            title: self.title,
-            description: self.description,
-            email: self.email,
-            version: self.version,
-            thumbnail: self.thumbnail,
-            urls: self.urls.map(|i| i.into()),
-            stats: self.stats.into(),
-            languages: self.languages,
-            registrations: self.registrations,
-            approval_required: self.approval_required,
-            invites_enabled: Some(self.invites_enabled),
-            contact_account: Some(self.contact_account.into()),
+            uri: val.uri,
+            title: val.title,
+            description: val.description,
+            email: val.email,
+            version: val.version,
+            thumbnail: val.thumbnail,
+            urls: val.urls.map(|i| i.into()),
+            stats: val.stats.into(),
+            languages: val.languages,
+            registrations: val.registrations,
+            approval_required: val.approval_required,
+            invites_enabled: Some(val.invites_enabled),
+            contact_account: Some(val.contact_account.into()),
             configuration: MegalodonEntities::instance::InstanceConfig {
                 statuses: MegalodonEntities::instance::Statuses {
-                    max_characters: self.max_toot_chars,
+                    max_characters: val.max_toot_chars,
                     max_media_attachments: None,
                     characters_reserved_per_url: None,
                 },
                 polls: None,
             },
-            rules: Some(self.rules.into_iter().map(|r| r.into()).collect()),
+            rules: Some(val.rules.into_iter().map(|r| r.into()).collect()),
         }
     }
 }
 
-impl Into<MegalodonEntities::instance::InstanceRule> for InstanceRule {
-    fn into(self) -> MegalodonEntities::instance::InstanceRule {
+impl From<InstanceRule> for MegalodonEntities::instance::InstanceRule {
+    fn from(val: InstanceRule) -> Self {
         MegalodonEntities::instance::InstanceRule {
-            id: self.id,
-            text: self.text,
+            id: val.id,
+            text: val.text,
         }
     }
 }

--- a/src/friendica/entities/list.rs
+++ b/src/friendica/entities/list.rs
@@ -16,9 +16,9 @@ pub enum RepliesPolicy {
     None,
 }
 
-impl Into<MegalodonEntities::list::RepliesPolicy> for RepliesPolicy {
-    fn into(self) -> MegalodonEntities::list::RepliesPolicy {
-        match self {
+impl From<RepliesPolicy> for MegalodonEntities::list::RepliesPolicy {
+    fn from(val: RepliesPolicy) -> Self {
+        match val {
             RepliesPolicy::Followed => MegalodonEntities::list::RepliesPolicy::Followed,
             RepliesPolicy::List => MegalodonEntities::list::RepliesPolicy::List,
             RepliesPolicy::None => MegalodonEntities::list::RepliesPolicy::None,
@@ -26,12 +26,12 @@ impl Into<MegalodonEntities::list::RepliesPolicy> for RepliesPolicy {
     }
 }
 
-impl Into<MegalodonEntities::List> for List {
-    fn into(self) -> MegalodonEntities::List {
+impl From<List> for MegalodonEntities::List {
+    fn from(val: List) -> Self {
         MegalodonEntities::List {
-            id: self.id,
-            title: self.title,
-            replies_policy: Some(self.replies_policy.into()),
+            id: val.id,
+            title: val.title,
+            replies_policy: Some(val.replies_policy.into()),
         }
     }
 }

--- a/src/friendica/entities/marker.rs
+++ b/src/friendica/entities/marker.rs
@@ -15,21 +15,21 @@ struct InnerMarker {
     updated_at: DateTime<Utc>,
 }
 
-impl Into<MegalodonEntities::Marker> for Marker {
-    fn into(self) -> MegalodonEntities::Marker {
+impl From<Marker> for MegalodonEntities::Marker {
+    fn from(val: Marker) -> Self {
         MegalodonEntities::Marker {
-            home: self.home.map(|i| i.into()),
-            notifications: self.notifications.map(|i| i.into()),
+            home: val.home.map(|i| i.into()),
+            notifications: val.notifications.map(|i| i.into()),
         }
     }
 }
 
-impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
-    fn into(self) -> MegalodonEntities::marker::InnerMarker {
+impl From<InnerMarker> for MegalodonEntities::marker::InnerMarker {
+    fn from(val: InnerMarker) -> Self {
         MegalodonEntities::marker::InnerMarker {
-            last_read_id: self.last_read_id,
-            version: self.version,
-            updated_at: self.updated_at,
+            last_read_id: val.last_read_id,
+            version: val.version,
+            updated_at: val.updated_at,
             unread_count: None,
         }
     }

--- a/src/friendica/entities/mention.rs
+++ b/src/friendica/entities/mention.rs
@@ -9,13 +9,13 @@ pub struct Mention {
     acct: String,
 }
 
-impl Into<MegalodonEntities::Mention> for Mention {
-    fn into(self) -> MegalodonEntities::Mention {
+impl From<Mention> for MegalodonEntities::Mention {
+    fn from(val: Mention) -> Self {
         MegalodonEntities::Mention {
-            id: self.id,
-            username: self.username,
-            url: self.url,
-            acct: self.acct,
+            id: val.id,
+            username: val.username,
+            url: val.url,
+            acct: val.acct,
         }
     }
 }

--- a/src/friendica/entities/notification.rs
+++ b/src/friendica/entities/notification.rs
@@ -25,9 +25,9 @@ pub enum NotificationType {
     Update,
 }
 
-impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
-    fn into(self) -> MegalodonEntities::notification::NotificationType {
-        match self {
+impl From<NotificationType> for MegalodonEntities::notification::NotificationType {
+    fn from(val: NotificationType) -> Self {
+        match val {
             NotificationType::Follow => MegalodonEntities::notification::NotificationType::Follow,
             NotificationType::FollowRequest => {
                 MegalodonEntities::notification::NotificationType::FollowRequest
@@ -46,16 +46,16 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
     }
 }
 
-impl Into<MegalodonEntities::Notification> for Notification {
-    fn into(self) -> MegalodonEntities::Notification {
+impl From<Notification> for MegalodonEntities::Notification {
+    fn from(val: Notification) -> Self {
         MegalodonEntities::Notification {
-            account: Some(self.account.into()),
-            created_at: self.created_at,
-            id: self.id,
-            status: self.status.map(|i| i.into()),
+            account: Some(val.account.into()),
+            created_at: val.created_at,
+            id: val.id,
+            status: val.status.map(|i| i.into()),
             reaction: None,
             target: None,
-            r#type: self.r#type.into(),
+            r#type: val.r#type.into(),
         }
     }
 }

--- a/src/friendica/entities/poll.rs
+++ b/src/friendica/entities/poll.rs
@@ -16,18 +16,18 @@ pub struct Poll {
     emojis: Vec<Emoji>,
 }
 
-impl Into<MegalodonEntities::Poll> for Poll {
-    fn into(self) -> MegalodonEntities::Poll {
+impl From<Poll> for MegalodonEntities::Poll {
+    fn from(val: Poll) -> Self {
         MegalodonEntities::Poll {
-            id: self.id,
-            expires_at: self.expires_at,
-            expired: self.expired,
-            multiple: self.multiple,
-            votes_count: self.votes_count,
-            voters_count: self.voters_count,
-            options: self.options.into_iter().map(|i| i.into()).collect(),
-            voted: self.voted,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            expires_at: val.expires_at,
+            expired: val.expired,
+            multiple: val.multiple,
+            votes_count: val.votes_count,
+            voters_count: val.voters_count,
+            options: val.options.into_iter().map(|i| i.into()).collect(),
+            voted: val.voted,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/friendica/entities/poll_option.rs
+++ b/src/friendica/entities/poll_option.rs
@@ -7,11 +7,11 @@ pub struct PollOption {
     votes_count: Option<u32>,
 }
 
-impl Into<MegalodonEntities::PollOption> for PollOption {
-    fn into(self) -> MegalodonEntities::PollOption {
+impl From<PollOption> for MegalodonEntities::PollOption {
+    fn from(val: PollOption) -> Self {
         MegalodonEntities::PollOption {
-            title: self.title,
-            votes_count: self.votes_count,
+            title: val.title,
+            votes_count: val.votes_count,
         }
     }
 }

--- a/src/friendica/entities/preferences.rs
+++ b/src/friendica/entities/preferences.rs
@@ -199,21 +199,21 @@ impl<'de> de::Deserialize<'de> for Preferences {
     }
 }
 
-impl Into<MegalodonEntities::Preferences> for Preferences {
-    fn into(self) -> MegalodonEntities::Preferences {
+impl From<Preferences> for MegalodonEntities::Preferences {
+    fn from(val: Preferences) -> Self {
         MegalodonEntities::Preferences {
-            posting_default_visibility: self.posting_default_visibility.into(),
-            posting_default_sensitive: self.posting_default_sensitive.into(),
-            posting_default_language: self.posting_default_language.into(),
-            reading_expand_media: self.reading_expand_media.into(),
-            reading_expand_spoilers: self.reading_expand_spoilers.into(),
+            posting_default_visibility: val.posting_default_visibility.into(),
+            posting_default_sensitive: val.posting_default_sensitive.into(),
+            posting_default_language: val.posting_default_language.into(),
+            reading_expand_media: val.reading_expand_media.into(),
+            reading_expand_spoilers: val.reading_expand_spoilers.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::preferences::ExpandMedia> for ExpandMedia {
-    fn into(self) -> MegalodonEntities::preferences::ExpandMedia {
-        match self {
+impl From<ExpandMedia> for MegalodonEntities::preferences::ExpandMedia {
+    fn from(val: ExpandMedia) -> Self {
+        match val {
             ExpandMedia::Default => MegalodonEntities::preferences::ExpandMedia::Default,
             ExpandMedia::ShowAll => MegalodonEntities::preferences::ExpandMedia::ShowAll,
             ExpandMedia::HideAll => MegalodonEntities::preferences::ExpandMedia::HideAll,

--- a/src/friendica/entities/push_subscription.rs
+++ b/src/friendica/entities/push_subscription.rs
@@ -18,25 +18,25 @@ struct Alerts {
     poll: bool,
 }
 
-impl Into<MegalodonEntities::PushSubscription> for PushSubscription {
-    fn into(self) -> MegalodonEntities::PushSubscription {
+impl From<PushSubscription> for MegalodonEntities::PushSubscription {
+    fn from(val: PushSubscription) -> Self {
         MegalodonEntities::PushSubscription {
-            id: self.id,
-            endpoint: self.endpoint,
-            server_key: self.server_key,
-            alerts: self.alerts.into(),
+            id: val.id,
+            endpoint: val.endpoint,
+            server_key: val.server_key,
+            alerts: val.alerts.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::push_subscription::Alerts> for Alerts {
-    fn into(self) -> MegalodonEntities::push_subscription::Alerts {
+impl From<Alerts> for MegalodonEntities::push_subscription::Alerts {
+    fn from(val: Alerts) -> Self {
         MegalodonEntities::push_subscription::Alerts {
-            follow: self.follow,
-            favourite: self.favourite,
-            mention: self.mention,
-            reblog: self.reblog,
-            poll: self.poll,
+            follow: val.follow,
+            favourite: val.favourite,
+            mention: val.mention,
+            reblog: val.reblog,
+            poll: val.poll,
         }
     }
 }

--- a/src/friendica/entities/relationship.rs
+++ b/src/friendica/entities/relationship.rs
@@ -18,22 +18,22 @@ pub struct Relationship {
     note: Option<String>,
 }
 
-impl Into<MegalodonEntities::Relationship> for Relationship {
-    fn into(self) -> MegalodonEntities::Relationship {
+impl From<Relationship> for MegalodonEntities::Relationship {
+    fn from(val: Relationship) -> Self {
         MegalodonEntities::Relationship {
-            id: self.id,
-            following: self.following,
-            followed_by: self.followed_by,
-            blocking: self.blocking,
-            blocked_by: self.blocked_by,
-            muting: self.muting,
-            muting_notifications: self.muting_notifications,
-            requested: self.requested,
-            domain_blocking: self.domain_blocking,
-            showing_reblogs: self.showing_reblogs,
-            endorsed: self.endorsed,
-            notifying: self.notifying,
-            note: self.note,
+            id: val.id,
+            following: val.following,
+            followed_by: val.followed_by,
+            blocking: val.blocking,
+            blocked_by: val.blocked_by,
+            muting: val.muting,
+            muting_notifications: val.muting_notifications,
+            requested: val.requested,
+            domain_blocking: val.domain_blocking,
+            showing_reblogs: val.showing_reblogs,
+            endorsed: val.endorsed,
+            notifying: val.notifying,
+            note: val.note,
         }
     }
 }

--- a/src/friendica/entities/report.rs
+++ b/src/friendica/entities/report.rs
@@ -22,9 +22,9 @@ pub enum Category {
     Other,
 }
 
-impl Into<MegalodonEntities::report::Category> for Category {
-    fn into(self) -> MegalodonEntities::report::Category {
-        match self {
+impl From<Category> for MegalodonEntities::report::Category {
+    fn from(val: Category) -> Self {
+        match val {
             Category::Spam => MegalodonEntities::report::Category::Spam,
             Category::Violation => MegalodonEntities::report::Category::Violation,
             Category::Other => MegalodonEntities::report::Category::Other,
@@ -32,18 +32,18 @@ impl Into<MegalodonEntities::report::Category> for Category {
     }
 }
 
-impl Into<MegalodonEntities::Report> for Report {
-    fn into(self) -> MegalodonEntities::Report {
+impl From<Report> for MegalodonEntities::Report {
+    fn from(val: Report) -> Self {
         MegalodonEntities::Report {
-            id: self.id,
-            action_taken: self.action_taken,
+            id: val.id,
+            action_taken: val.action_taken,
             action_taken_at: None,
-            category: Some(self.category.into()),
-            comment: Some(self.comment),
-            forwarded: Some(self.forwarded),
-            status_ids: self.status_ids,
-            rule_ids: self.rule_ids,
-            target_account: Some(self.target_account.into()),
+            category: Some(val.category.into()),
+            comment: Some(val.comment),
+            forwarded: Some(val.forwarded),
+            status_ids: val.status_ids,
+            rule_ids: val.rule_ids,
+            target_account: Some(val.target_account.into()),
         }
     }
 }

--- a/src/friendica/entities/results.rs
+++ b/src/friendica/entities/results.rs
@@ -9,12 +9,12 @@ pub struct Results {
     hashtags: Vec<Tag>,
 }
 
-impl Into<MegalodonEntities::Results> for Results {
-    fn into(self) -> MegalodonEntities::Results {
+impl From<Results> for MegalodonEntities::Results {
+    fn from(val: Results) -> Self {
         MegalodonEntities::Results {
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            statuses: self.statuses.into_iter().map(|i| i.into()).collect(),
-            hashtags: self.hashtags.into_iter().map(|i| i.into()).collect(),
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            statuses: val.statuses.into_iter().map(|i| i.into()).collect(),
+            hashtags: val.hashtags.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/friendica/entities/scheduled_status.rs
+++ b/src/friendica/entities/scheduled_status.rs
@@ -11,14 +11,14 @@ pub struct ScheduledStatus {
     media_attachments: Vec<Attachment>,
 }
 
-impl Into<MegalodonEntities::ScheduledStatus> for ScheduledStatus {
-    fn into(self) -> MegalodonEntities::ScheduledStatus {
+impl From<ScheduledStatus> for MegalodonEntities::ScheduledStatus {
+    fn from(val: ScheduledStatus) -> Self {
         MegalodonEntities::ScheduledStatus {
-            id: self.id,
-            scheduled_at: self.scheduled_at,
-            params: self.params.into(),
+            id: val.id,
+            scheduled_at: val.scheduled_at,
+            params: val.params.into(),
             media_attachments: Some(
-                self.media_attachments
+                val.media_attachments
                     .into_iter()
                     .map(|i| i.into())
                     .collect(),
@@ -27,8 +27,8 @@ impl Into<MegalodonEntities::ScheduledStatus> for ScheduledStatus {
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for ScheduledStatus {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::ScheduledStatus(self.into())
+impl From<ScheduledStatus> for megalodon::PostStatusOutput {
+    fn from(val: ScheduledStatus) -> Self {
+        megalodon::PostStatusOutput::ScheduledStatus(val.into())
     }
 }

--- a/src/friendica/entities/source.rs
+++ b/src/friendica/entities/source.rs
@@ -25,14 +25,14 @@ impl From<MegalodonEntities::Source> for Source {
     }
 }
 
-impl Into<MegalodonEntities::Source> for Source {
-    fn into(self) -> MegalodonEntities::Source {
+impl From<Source> for MegalodonEntities::Source {
+    fn from(val: Source) -> Self {
         MegalodonEntities::Source {
-            privacy: self.privacy,
-            sensitive: self.sensitive,
-            language: self.language,
-            note: self.note,
-            fields: self
+            privacy: val.privacy,
+            sensitive: val.sensitive,
+            language: val.language,
+            note: val.note,
+            fields: val
                 .fields
                 .map(|i| i.into_iter().map(|j| j.into()).collect()),
         }

--- a/src/friendica/entities/stats.rs
+++ b/src/friendica/entities/stats.rs
@@ -8,12 +8,12 @@ pub struct Stats {
     domain_count: u32,
 }
 
-impl Into<MegalodonEntities::Stats> for Stats {
-    fn into(self) -> MegalodonEntities::Stats {
+impl From<Stats> for MegalodonEntities::Stats {
+    fn from(val: Stats) -> Self {
         MegalodonEntities::Stats {
-            user_count: self.user_count,
-            status_count: self.status_count,
-            domain_count: self.domain_count,
+            user_count: val.user_count,
+            status_count: val.status_count,
+            domain_count: val.domain_count,
         }
     }
 }

--- a/src/friendica/entities/status.rs
+++ b/src/friendica/entities/status.rs
@@ -78,17 +78,17 @@ pub struct Tag {
     pub url: String,
 }
 
-impl Into<MegalodonEntities::status::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::status::Tag {
+impl From<Tag> for MegalodonEntities::status::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::status::Tag {
-            name: self.name,
-            url: self.url,
+            name: val.name,
+            url: val.url,
         }
     }
 }
-impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
-    fn into(self) -> MegalodonEntities::status::StatusVisibility {
-        match self {
+impl From<StatusVisibility> for MegalodonEntities::status::StatusVisibility {
+    fn from(val: StatusVisibility) -> Self {
+        match val {
             StatusVisibility::Public => MegalodonEntities::status::StatusVisibility::Public,
             StatusVisibility::Unlisted => MegalodonEntities::status::StatusVisibility::Unlisted,
             StatusVisibility::Private => MegalodonEntities::status::StatusVisibility::Private,
@@ -96,62 +96,62 @@ impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
     }
 }
 
-impl Into<MegalodonEntities::Status> for Status {
-    fn into(self) -> MegalodonEntities::Status {
+impl From<Status> for MegalodonEntities::Status {
+    fn from(val: Status) -> Self {
         let mut reblog_status: Option<Box<MegalodonEntities::Status>> = None;
         let mut quoted = false;
-        if let Some(reblog) = self.reblog {
+        if let Some(reblog) = val.reblog {
             let rs: Status = *reblog;
             reblog_status = Some(Box::new(rs.into()));
-        } else if let Some(quote) = self.quote {
+        } else if let Some(quote) = val.quote {
             let rs: Status = *quote;
             reblog_status = Some(Box::new(rs.into()));
             quoted = true;
         }
 
         MegalodonEntities::Status {
-            id: self.id,
-            uri: self.uri,
-            url: self.url,
-            account: self.account.into(),
-            in_reply_to_id: self.in_reply_to_id,
-            in_reply_to_account_id: self.in_reply_to_account_id,
+            id: val.id,
+            uri: val.uri,
+            url: val.url,
+            account: val.account.into(),
+            in_reply_to_id: val.in_reply_to_id,
+            in_reply_to_account_id: val.in_reply_to_account_id,
             reblog: reblog_status,
-            content: self.content,
+            content: val.content,
             plain_content: None,
-            created_at: self.created_at,
+            created_at: val.created_at,
             edited_at: None,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            replies_count: self.replies_count,
-            reblogs_count: self.reblogs_count,
-            favourites_count: self.favourites_count,
-            reblogged: self.reblogged,
-            favourited: self.favourited,
-            muted: self.muted,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.into(),
-            media_attachments: self
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            replies_count: val.replies_count,
+            reblogs_count: val.reblogs_count,
+            favourites_count: val.favourites_count,
+            reblogged: val.reblogged,
+            favourited: val.favourited,
+            muted: val.muted,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.into(),
+            media_attachments: val
                 .media_attachments
                 .into_iter()
                 .map(|i| i.into())
                 .collect(),
-            mentions: self.mentions.into_iter().map(|i| i.into()).collect(),
-            tags: self.tags.into_iter().map(|i| i.into()).collect(),
-            card: self.card.map(|i| i.into()),
-            poll: self.poll.map(|i| i.into()),
-            application: self.application.map(|i| i.into()),
-            language: self.language,
-            pinned: self.pinned,
+            mentions: val.mentions.into_iter().map(|i| i.into()).collect(),
+            tags: val.tags.into_iter().map(|i| i.into()).collect(),
+            card: val.card.map(|i| i.into()),
+            poll: val.poll.map(|i| i.into()),
+            application: val.application.map(|i| i.into()),
+            language: val.language,
+            pinned: val.pinned,
             emoji_reactions: None,
             quote: quoted,
-            bookmarked: self.bookmarked,
+            bookmarked: val.bookmarked,
         }
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for Status {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::Status(self.into())
+impl From<Status> for megalodon::PostStatusOutput {
+    fn from(val: Status) -> Self {
+        megalodon::PostStatusOutput::Status(val.into())
     }
 }

--- a/src/friendica/entities/status_params.rs
+++ b/src/friendica/entities/status_params.rs
@@ -15,21 +15,21 @@ pub struct StatusParams {
     application_id: String,
 }
 
-impl Into<MegalodonEntities::StatusParams> for StatusParams {
-    fn into(self) -> MegalodonEntities::StatusParams {
+impl From<StatusParams> for MegalodonEntities::StatusParams {
+    fn from(val: StatusParams) -> Self {
         let mut app_id: Option<u32> = None;
-        if let Ok(val) = self.application_id.parse::<u32>() {
+        if let Ok(val) = val.application_id.parse::<u32>() {
             app_id = Some(val);
         }
 
         MegalodonEntities::StatusParams {
-            text: self.text,
-            in_reply_to_id: self.in_reply_to_id,
-            media_ids: self.media_ids,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.map(|i| i.into()),
-            scheduled_at: self.scheduled_at,
+            text: val.text,
+            in_reply_to_id: val.in_reply_to_id,
+            media_ids: val.media_ids,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.map(|i| i.into()),
+            scheduled_at: val.scheduled_at,
             application_id: app_id,
         }
     }

--- a/src/friendica/entities/tag.rs
+++ b/src/friendica/entities/tag.rs
@@ -10,13 +10,13 @@ pub struct Tag {
     following: Option<bool>,
 }
 
-impl Into<MegalodonEntities::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::Tag {
+impl From<Tag> for MegalodonEntities::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::Tag {
-            name: self.name,
-            url: self.url,
-            history: self.history.into_iter().map(|j| j.into()).collect(),
-            following: self.following,
+            name: val.name,
+            url: val.url,
+            history: val.history.into_iter().map(|j| j.into()).collect(),
+            following: val.following,
         }
     }
 }

--- a/src/friendica/entities/token.rs
+++ b/src/friendica/entities/token.rs
@@ -9,13 +9,13 @@ pub struct Token {
     created_at: u64,
 }
 
-impl Into<MegalodonEntities::Token> for Token {
-    fn into(self) -> MegalodonEntities::Token {
+impl From<Token> for MegalodonEntities::Token {
+    fn from(val: Token) -> Self {
         MegalodonEntities::Token {
-            access_token: self.access_token,
-            token_type: self.token_type,
-            scope: self.scope,
-            created_at: self.created_at,
+            access_token: val.access_token,
+            token_type: val.token_type,
+            scope: val.scope,
+            created_at: val.created_at,
         }
     }
 }

--- a/src/friendica/entities/urls.rs
+++ b/src/friendica/entities/urls.rs
@@ -6,10 +6,10 @@ pub struct URLs {
     streaming_api: String,
 }
 
-impl Into<MegalodonEntities::URLs> for URLs {
-    fn into(self) -> MegalodonEntities::URLs {
+impl From<URLs> for MegalodonEntities::URLs {
+    fn from(val: URLs) -> Self {
         MegalodonEntities::URLs {
-            streaming_api: self.streaming_api,
+            streaming_api: val.streaming_api,
         }
     }
 }

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -122,7 +122,7 @@ impl megalodon::Megalodon for Friendica {
             .client
             .post::<oauth::AppDataFromServer>("/api/v1/apps", &params, None)
             .await?;
-        Ok(MegalodonOAuth::AppData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn fetch_access_token(
@@ -146,7 +146,7 @@ impl megalodon::Megalodon for Friendica {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn refresh_access_token(
@@ -168,7 +168,7 @@ impl megalodon::Megalodon for Friendica {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn revoke_access_token(
@@ -1267,7 +1267,10 @@ impl megalodon::Megalodon for Friendica {
         ))
     }
 
-    async fn get_status_source(&self, _id: String) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
+    async fn get_status_source(
+        &self,
+        _id: String,
+    ) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
         // Check https://wiki.friendi.ca/docs/api-mastodon#currently_unimplemented_endpoints
         Err(Error::new_own(
             "Friendica does not support".to_string(),

--- a/src/friendica/oauth.rs
+++ b/src/friendica/oauth.rs
@@ -20,26 +20,26 @@ pub struct TokenDataFromServer {
     created_at: u64,
 }
 
-impl Into<oauth::AppData> for AppDataFromServer {
-    fn into(self) -> oauth::AppData {
+impl From<AppDataFromServer> for oauth::AppData {
+    fn from(val: AppDataFromServer) -> Self {
         oauth::AppData::new(
-            self.id,
-            self.name,
-            self.website,
-            Some(self.redirect_uri),
-            self.client_id,
-            self.client_secret,
+            val.id,
+            val.name,
+            val.website,
+            Some(val.redirect_uri),
+            val.client_id,
+            val.client_secret,
         )
     }
 }
 
-impl Into<oauth::TokenData> for TokenDataFromServer {
-    fn into(self) -> oauth::TokenData {
+impl From<TokenDataFromServer> for oauth::TokenData {
+    fn from(val: TokenDataFromServer) -> Self {
         oauth::TokenData::new(
-            self.access_token,
-            self.token_type,
-            Some(self.scope),
-            Some(self.created_at),
+            val.access_token,
+            val.token_type,
+            Some(val.scope),
+            Some(val.created_at),
             None,
             None,
         )

--- a/src/mastodon/entities/account.rs
+++ b/src/mastodon/entities/account.rs
@@ -79,47 +79,47 @@ impl From<MegalodonEntities::Account> for Account {
     }
 }
 
-impl Into<MegalodonEntities::Account> for Account {
-    fn into(self) -> MegalodonEntities::Account {
+impl From<Account> for MegalodonEntities::Account {
+    fn from(val: Account) -> Self {
         let mut moved_account: Option<Box<MegalodonEntities::Account>> = None;
-        if let Some(moved) = self.moved {
+        if let Some(moved) = val.moved {
             let ma: Account = *moved;
             moved_account = Some(Box::new(ma.into()));
         }
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
-            acct: self.acct,
-            display_name: self.display_name,
-            locked: self.locked,
-            discoverable: self.discoverable,
-            group: Some(self.group),
-            noindex: self.noindex,
-            suspended: self.suspended,
-            limited: self.limited,
-            created_at: self.created_at,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.statuses_count,
-            note: self.note,
-            url: self.url,
-            avatar: self.avatar,
-            avatar_static: self.avatar_static,
-            header: self.header,
-            header_static: self.header_static,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            username: val.username,
+            acct: val.acct,
+            display_name: val.display_name,
+            locked: val.locked,
+            discoverable: val.discoverable,
+            group: Some(val.group),
+            noindex: val.noindex,
+            suspended: val.suspended,
+            limited: val.limited,
+            created_at: val.created_at,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.statuses_count,
+            note: val.note,
+            url: val.url,
+            avatar: val.avatar,
+            avatar_static: val.avatar_static,
+            header: val.header,
+            header_static: val.header_static,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
             moved: moved_account,
-            fields: self.fields.into_iter().map(|j| j.into()).collect(),
-            bot: self.bot,
-            source: self.source.map(|i| i.into()),
-            role: self.role.map(|i| i.into()),
-            mute_expires_at: self.mute_expires_at,
+            fields: val.fields.into_iter().map(|j| j.into()).collect(),
+            bot: val.bot,
+            source: val.source.map(|i| i.into()),
+            role: val.role.map(|i| i.into()),
+            mute_expires_at: val.mute_expires_at,
         }
     }
 }
 
-impl Into<megalodon::FollowRequestOutput> for Account {
-    fn into(self) -> megalodon::FollowRequestOutput {
-        megalodon::FollowRequestOutput::Account(self.into())
+impl From<Account> for megalodon::FollowRequestOutput {
+    fn from(val: Account) -> Self {
+        megalodon::FollowRequestOutput::Account(val.into())
     }
 }

--- a/src/mastodon/entities/activity.rs
+++ b/src/mastodon/entities/activity.rs
@@ -9,13 +9,13 @@ pub struct Activity {
     registrations: String,
 }
 
-impl Into<MegalodonEntities::Activity> for Activity {
-    fn into(self) -> MegalodonEntities::Activity {
+impl From<Activity> for MegalodonEntities::Activity {
+    fn from(val: Activity) -> Self {
         MegalodonEntities::Activity {
-            week: self.week,
-            statuses: self.statuses,
-            logins: self.logins,
-            registrations: self.registrations,
+            week: val.week,
+            statuses: val.statuses,
+            logins: val.logins,
+            registrations: val.registrations,
         }
     }
 }

--- a/src/mastodon/entities/announcement.rs
+++ b/src/mastodon/entities/announcement.rs
@@ -44,55 +44,55 @@ pub struct Reaction {
     static_url: Option<String>,
 }
 
-impl Into<MegalodonEntities::Announcement> for Announcement {
-    fn into(self) -> MegalodonEntities::Announcement {
+impl From<Announcement> for MegalodonEntities::Announcement {
+    fn from(val: Announcement) -> Self {
         MegalodonEntities::Announcement {
-            id: self.id,
-            content: self.content,
-            starts_at: self.starts_at,
-            ends_at: self.ends_at,
-            published: self.published,
-            all_day: self.all_day,
-            published_at: self.published_at,
-            updated_at: Some(self.updated_at),
-            read: self.read,
-            mentions: self.mentions.into_iter().map(|i| i.into()).collect(),
-            statuses: self.statuses.into_iter().map(|i| i.into()).collect(),
-            tags: self.tags.into_iter().map(|i| i.into()).collect(),
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            reactions: self.reactions.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            content: val.content,
+            starts_at: val.starts_at,
+            ends_at: val.ends_at,
+            published: val.published,
+            all_day: val.all_day,
+            published_at: val.published_at,
+            updated_at: Some(val.updated_at),
+            read: val.read,
+            mentions: val.mentions.into_iter().map(|i| i.into()).collect(),
+            statuses: val.statuses.into_iter().map(|i| i.into()).collect(),
+            tags: val.tags.into_iter().map(|i| i.into()).collect(),
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            reactions: val.reactions.into_iter().map(|i| i.into()).collect(),
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Account> for Account {
-    fn into(self) -> MegalodonEntities::announcement::Account {
+impl From<Account> for MegalodonEntities::announcement::Account {
+    fn from(val: Account) -> Self {
         MegalodonEntities::announcement::Account {
-            id: self.id,
-            username: self.username,
-            url: self.url,
-            acct: self.acct,
+            id: val.id,
+            username: val.username,
+            url: val.url,
+            acct: val.acct,
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Status> for Status {
-    fn into(self) -> MegalodonEntities::announcement::Status {
+impl From<Status> for MegalodonEntities::announcement::Status {
+    fn from(val: Status) -> Self {
         MegalodonEntities::announcement::Status {
-            id: self.id,
-            url: self.url,
+            id: val.id,
+            url: val.url,
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Reaction> for Reaction {
-    fn into(self) -> MegalodonEntities::announcement::Reaction {
+impl From<Reaction> for MegalodonEntities::announcement::Reaction {
+    fn from(val: Reaction) -> Self {
         MegalodonEntities::announcement::Reaction {
-            name: self.name,
-            count: self.count,
-            me: self.me,
-            url: self.url,
-            static_url: self.static_url,
+            name: val.name,
+            count: val.count,
+            me: val.me,
+            url: val.url,
+            static_url: val.static_url,
         }
     }
 }

--- a/src/mastodon/entities/application.rs
+++ b/src/mastodon/entities/application.rs
@@ -8,12 +8,12 @@ pub struct Application {
     vapid_key: Option<String>,
 }
 
-impl Into<MegalodonEntities::Application> for Application {
-    fn into(self) -> MegalodonEntities::Application {
+impl From<Application> for MegalodonEntities::Application {
+    fn from(val: Application) -> Self {
         MegalodonEntities::Application {
-            name: self.name,
-            website: self.website,
-            vapid_key: self.vapid_key,
+            name: val.name,
+            website: val.website,
+            vapid_key: val.vapid_key,
         }
     }
 }

--- a/src/mastodon/entities/attachment.rs
+++ b/src/mastodon/entities/attachment.rs
@@ -63,9 +63,9 @@ pub enum AttachmentType {
     Unknown,
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentType {
-        match self {
+impl From<AttachmentType> for MegalodonEntities::attachment::AttachmentType {
+    fn from(val: AttachmentType) -> Self {
+        match val {
             AttachmentType::Image => MegalodonEntities::attachment::AttachmentType::Image,
             AttachmentType::Gifv => MegalodonEntities::attachment::AttachmentType::Gifv,
             AttachmentType::Video => MegalodonEntities::attachment::AttachmentType::Video,
@@ -75,91 +75,88 @@ impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
     }
 }
 
-impl Into<MegalodonEntities::Attachment> for Attachment {
-    fn into(self) -> MegalodonEntities::Attachment {
+impl From<Attachment> for MegalodonEntities::Attachment {
+    fn from(val: Attachment) -> Self {
         MegalodonEntities::Attachment {
-            id: self.id,
-            r#type: self.r#type.into(),
-            url: self.url.unwrap(),
-            remote_url: self.remote_url,
-            preview_url: self.preview_url,
-            text_url: self.text_url,
-            meta: self.meta.map(|i| i.into()),
-            description: self.description,
-            blurhash: self.blurhash,
+            id: val.id,
+            r#type: val.r#type.into(),
+            url: val.url.unwrap(),
+            remote_url: val.remote_url,
+            preview_url: val.preview_url,
+            text_url: val.text_url,
+            meta: val.meta.map(|i| i.into()),
+            description: val.description,
+            blurhash: val.blurhash,
         }
     }
 }
 
-impl Into<MegalodonEntities::UploadMedia> for Attachment {
-    fn into(self) -> MegalodonEntities::UploadMedia {
-        if let Some(url) = self.url {
+impl From<Attachment> for MegalodonEntities::UploadMedia {
+    fn from(val: Attachment) -> Self {
+        if let Some(url) = val.url {
             MegalodonEntities::UploadMedia::Attachment(MegalodonEntities::Attachment {
-                id: self.id,
-                r#type: self.r#type.into(),
+                id: val.id,
+                r#type: val.r#type.into(),
                 url,
-                remote_url: self.remote_url,
-                preview_url: self.preview_url,
-                text_url: self.text_url,
-                meta: self.meta.map(|i| i.into()),
-                description: self.description,
-                blurhash: self.blurhash,
+                remote_url: val.remote_url,
+                preview_url: val.preview_url,
+                text_url: val.text_url,
+                meta: val.meta.map(|i| i.into()),
+                description: val.description,
+                blurhash: val.blurhash,
             })
         } else {
             MegalodonEntities::UploadMedia::AsyncAttachment(MegalodonEntities::AsyncAttachment {
-                id: self.id,
-                r#type: self.r#type.into(),
+                id: val.id,
+                r#type: val.r#type.into(),
                 url: None,
-                remote_url: self.remote_url,
-                preview_url: self.preview_url,
-                text_url: self.text_url,
-                meta: self.meta.map(|i| i.into()),
-                description: self.description,
-                blurhash: self.blurhash,
+                remote_url: val.remote_url,
+                preview_url: val.preview_url,
+                text_url: val.text_url,
+                meta: val.meta.map(|i| i.into()),
+                description: val.description,
+                blurhash: val.blurhash,
             })
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentMeta> for AttachmentMeta {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentMeta {
+impl From<AttachmentMeta> for MegalodonEntities::attachment::AttachmentMeta {
+    fn from(val: AttachmentMeta) -> Self {
         MegalodonEntities::attachment::AttachmentMeta {
-            original: self.original.map(|i| i.into()),
-            small: self.small.map(|i| i.into()),
-            focus: self.focus.map(|i| i.into()),
-            length: self.length,
-            duration: self.duration,
-            fps: self.fps,
-            size: self.size,
-            width: self.width,
-            height: self.height,
-            aspect: self.aspect,
-            audio_encode: self.audio_encode,
-            audio_bitrate: self.audio_bitrate,
-            audio_channel: self.audio_channel,
+            original: val.original.map(|i| i.into()),
+            small: val.small.map(|i| i.into()),
+            focus: val.focus.map(|i| i.into()),
+            length: val.length,
+            duration: val.duration,
+            fps: val.fps,
+            size: val.size,
+            width: val.width,
+            height: val.height,
+            aspect: val.aspect,
+            audio_encode: val.audio_encode,
+            audio_bitrate: val.audio_bitrate,
+            audio_channel: val.audio_channel,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::MetaSub> for MetaSub {
-    fn into(self) -> MegalodonEntities::attachment::MetaSub {
+impl From<MetaSub> for MegalodonEntities::attachment::MetaSub {
+    fn from(val: MetaSub) -> Self {
         MegalodonEntities::attachment::MetaSub {
-            width: self.width,
-            height: self.height,
-            size: self.size,
-            aspect: self.aspect,
-            frame_rate: self.frame_rate,
-            duration: self.duration,
-            bitrate: self.bitrate,
+            width: val.width,
+            height: val.height,
+            size: val.size,
+            aspect: val.aspect,
+            frame_rate: val.frame_rate,
+            duration: val.duration,
+            bitrate: val.bitrate,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::Focus> for Focus {
-    fn into(self) -> MegalodonEntities::attachment::Focus {
-        MegalodonEntities::attachment::Focus {
-            x: self.x,
-            y: self.y,
-        }
+impl From<Focus> for MegalodonEntities::attachment::Focus {
+    fn from(val: Focus) -> Self {
+        MegalodonEntities::attachment::Focus { x: val.x, y: val.y }
     }
 }

--- a/src/mastodon/entities/card.rs
+++ b/src/mastodon/entities/card.rs
@@ -28,9 +28,9 @@ pub enum CardType {
     Rich,
 }
 
-impl Into<MegalodonEntities::card::CardType> for CardType {
-    fn into(self) -> MegalodonEntities::card::CardType {
-        match self {
+impl From<CardType> for MegalodonEntities::card::CardType {
+    fn from(val: CardType) -> Self {
+        match val {
             CardType::Link => MegalodonEntities::card::CardType::Link,
             CardType::Photo => MegalodonEntities::card::CardType::Photo,
             CardType::Video => MegalodonEntities::card::CardType::Video,
@@ -39,23 +39,23 @@ impl Into<MegalodonEntities::card::CardType> for CardType {
     }
 }
 
-impl Into<MegalodonEntities::Card> for Card {
-    fn into(self) -> MegalodonEntities::Card {
+impl From<Card> for MegalodonEntities::Card {
+    fn from(val: Card) -> Self {
         MegalodonEntities::Card {
-            url: self.url,
-            title: self.title,
-            description: self.description,
-            r#type: self.r#type.into(),
-            image: self.image,
-            author_name: Some(self.author_name),
-            author_url: Some(self.author_url),
-            provider_name: self.provider_name,
-            provider_url: self.provider_url,
-            html: Some(self.html),
-            width: Some(self.width),
-            height: Some(self.height),
-            embed_url: Some(self.embed_url),
-            blurhash: self.blurhash,
+            url: val.url,
+            title: val.title,
+            description: val.description,
+            r#type: val.r#type.into(),
+            image: val.image,
+            author_name: Some(val.author_name),
+            author_url: Some(val.author_url),
+            provider_name: val.provider_name,
+            provider_url: val.provider_url,
+            html: Some(val.html),
+            width: Some(val.width),
+            height: Some(val.height),
+            embed_url: Some(val.embed_url),
+            blurhash: val.blurhash,
         }
     }
 }

--- a/src/mastodon/entities/context.rs
+++ b/src/mastodon/entities/context.rs
@@ -8,11 +8,11 @@ pub struct Context {
     descendants: Vec<Status>,
 }
 
-impl Into<MegalodonEntities::Context> for Context {
-    fn into(self) -> MegalodonEntities::Context {
+impl From<Context> for MegalodonEntities::Context {
+    fn from(val: Context) -> Self {
         MegalodonEntities::Context {
-            ancestors: self.ancestors.into_iter().map(|i| i.into()).collect(),
-            descendants: self.descendants.into_iter().map(|i| i.into()).collect(),
+            ancestors: val.ancestors.into_iter().map(|i| i.into()).collect(),
+            descendants: val.descendants.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/mastodon/entities/conversation.rs
+++ b/src/mastodon/entities/conversation.rs
@@ -10,13 +10,13 @@ pub struct Conversation {
     unread: bool,
 }
 
-impl Into<MegalodonEntities::Conversation> for Conversation {
-    fn into(self) -> MegalodonEntities::Conversation {
+impl From<Conversation> for MegalodonEntities::Conversation {
+    fn from(val: Conversation) -> Self {
         MegalodonEntities::Conversation {
-            id: self.id,
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            last_status: self.last_status.map(|i| i.into()),
-            unread: self.unread,
+            id: val.id,
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            last_status: val.last_status.map(|i| i.into()),
+            unread: val.unread,
         }
     }
 }

--- a/src/mastodon/entities/emoji.rs
+++ b/src/mastodon/entities/emoji.rs
@@ -22,14 +22,14 @@ impl From<MegalodonEntities::Emoji> for Emoji {
     }
 }
 
-impl Into<MegalodonEntities::Emoji> for Emoji {
-    fn into(self) -> MegalodonEntities::Emoji {
+impl From<Emoji> for MegalodonEntities::Emoji {
+    fn from(val: Emoji) -> Self {
         MegalodonEntities::Emoji {
-            shortcode: self.shortcode,
-            static_url: self.static_url,
-            url: self.url,
-            visible_in_picker: self.visible_in_picker,
-            category: self.category,
+            shortcode: val.shortcode,
+            static_url: val.static_url,
+            url: val.url,
+            visible_in_picker: val.visible_in_picker,
+            category: val.category,
         }
     }
 }

--- a/src/mastodon/entities/featured_tag.rs
+++ b/src/mastodon/entities/featured_tag.rs
@@ -10,13 +10,13 @@ pub struct FeaturedTag {
     last_status_at: DateTime<Utc>,
 }
 
-impl Into<MegalodonEntities::FeaturedTag> for FeaturedTag {
-    fn into(self) -> MegalodonEntities::FeaturedTag {
+impl From<FeaturedTag> for MegalodonEntities::FeaturedTag {
+    fn from(val: FeaturedTag) -> Self {
         MegalodonEntities::FeaturedTag {
-            id: self.id,
-            name: self.name,
-            statuses_count: self.statuses_count,
-            last_status_at: self.last_status_at,
+            id: val.id,
+            name: val.name,
+            statuses_count: val.statuses_count,
+            last_status_at: val.last_status_at,
         }
     }
 }

--- a/src/mastodon/entities/field.rs
+++ b/src/mastodon/entities/field.rs
@@ -19,12 +19,12 @@ impl From<MegalodonEntities::Field> for Field {
     }
 }
 
-impl Into<MegalodonEntities::Field> for Field {
-    fn into(self) -> MegalodonEntities::Field {
+impl From<Field> for MegalodonEntities::Field {
+    fn from(val: Field) -> Self {
         MegalodonEntities::Field {
-            name: self.name,
-            value: self.value,
-            verified_at: self.verified_at,
+            name: val.name,
+            value: val.value,
+            verified_at: val.verified_at,
             verified: None,
         }
     }

--- a/src/mastodon/entities/filter.rs
+++ b/src/mastodon/entities/filter.rs
@@ -21,9 +21,9 @@ pub enum FilterContext {
     Thread,
 }
 
-impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
-    fn into(self) -> MegalodonEntities::filter::FilterContext {
-        match self {
+impl From<FilterContext> for MegalodonEntities::filter::FilterContext {
+    fn from(val: FilterContext) -> Self {
+        match val {
             FilterContext::Home => MegalodonEntities::filter::FilterContext::Home,
             FilterContext::Notifications => MegalodonEntities::filter::FilterContext::Notifications,
             FilterContext::Public => MegalodonEntities::filter::FilterContext::Public,
@@ -32,15 +32,15 @@ impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
     }
 }
 
-impl Into<MegalodonEntities::Filter> for Filter {
-    fn into(self) -> MegalodonEntities::Filter {
+impl From<Filter> for MegalodonEntities::Filter {
+    fn from(val: Filter) -> Self {
         MegalodonEntities::Filter {
-            id: self.id,
-            phrase: self.phrase,
-            context: self.context.into_iter().map(|i| i.into()).collect(),
-            expires_at: self.expires_at,
-            irreversible: self.irreversible,
-            whole_word: self.whole_word,
+            id: val.id,
+            phrase: val.phrase,
+            context: val.context.into_iter().map(|i| i.into()).collect(),
+            expires_at: val.expires_at,
+            irreversible: val.irreversible,
+            whole_word: val.whole_word,
         }
     }
 }

--- a/src/mastodon/entities/history.rs
+++ b/src/mastodon/entities/history.rs
@@ -11,12 +11,12 @@ pub struct History {
     accounts: usize,
 }
 
-impl Into<MegalodonEntities::History> for History {
-    fn into(self) -> MegalodonEntities::History {
+impl From<History> for MegalodonEntities::History {
+    fn from(val: History) -> Self {
         MegalodonEntities::History {
-            day: self.day,
-            uses: self.uses,
-            accounts: self.accounts,
+            day: val.day,
+            uses: val.uses,
+            accounts: val.accounts,
         }
     }
 }

--- a/src/mastodon/entities/identity_proof.rs
+++ b/src/mastodon/entities/identity_proof.rs
@@ -11,14 +11,14 @@ pub struct IdentityProof {
     profile_url: String,
 }
 
-impl Into<MegalodonEntities::IdentityProof> for IdentityProof {
-    fn into(self) -> MegalodonEntities::IdentityProof {
+impl From<IdentityProof> for MegalodonEntities::IdentityProof {
+    fn from(val: IdentityProof) -> Self {
         MegalodonEntities::IdentityProof {
-            provider: self.provider,
-            provider_username: self.provider_username,
-            updated_at: self.updated_at,
-            proof_url: self.proof_url,
-            profile_url: self.profile_url,
+            provider: val.provider,
+            provider_username: val.provider_username,
+            updated_at: val.updated_at,
+            proof_url: val.proof_url,
+            profile_url: val.profile_url,
         }
     }
 }

--- a/src/mastodon/entities/instance.rs
+++ b/src/mastodon/entities/instance.rs
@@ -60,63 +60,63 @@ pub struct InstanceRule {
     pub text: String,
 }
 
-impl Into<MegalodonEntities::Instance> for Instance {
-    fn into(self) -> MegalodonEntities::Instance {
+impl From<Instance> for MegalodonEntities::Instance {
+    fn from(val: Instance) -> Self {
         MegalodonEntities::Instance {
-            uri: self.uri,
-            title: self.title,
-            description: self.description,
-            email: self.email,
-            version: self.version,
-            thumbnail: self.thumbnail,
-            urls: Some(self.urls.into()),
-            stats: self.stats.into(),
-            languages: self.languages,
-            registrations: self.registrations,
-            approval_required: self.approval_required,
-            invites_enabled: Some(self.invites_enabled),
-            contact_account: Some(self.contact_account.into()),
-            configuration: self.configuration.into(),
-            rules: Some(self.rules.into_iter().map(|r| r.into()).collect()),
+            uri: val.uri,
+            title: val.title,
+            description: val.description,
+            email: val.email,
+            version: val.version,
+            thumbnail: val.thumbnail,
+            urls: Some(val.urls.into()),
+            stats: val.stats.into(),
+            languages: val.languages,
+            registrations: val.registrations,
+            approval_required: val.approval_required,
+            invites_enabled: Some(val.invites_enabled),
+            contact_account: Some(val.contact_account.into()),
+            configuration: val.configuration.into(),
+            rules: Some(val.rules.into_iter().map(|r| r.into()).collect()),
         }
     }
 }
 
-impl Into<MegalodonEntities::instance::InstanceConfig> for InstanceConfig {
-    fn into(self) -> MegalodonEntities::instance::InstanceConfig {
+impl From<InstanceConfig> for MegalodonEntities::instance::InstanceConfig {
+    fn from(val: InstanceConfig) -> Self {
         MegalodonEntities::instance::InstanceConfig {
-            statuses: self.statuses.into(),
-            polls: Some(self.polls.into()),
+            statuses: val.statuses.into(),
+            polls: Some(val.polls.into()),
         }
     }
 }
 
-impl Into<MegalodonEntities::instance::Statuses> for Statuses {
-    fn into(self) -> MegalodonEntities::instance::Statuses {
+impl From<Statuses> for MegalodonEntities::instance::Statuses {
+    fn from(val: Statuses) -> Self {
         MegalodonEntities::instance::Statuses {
-            max_characters: self.max_characters,
-            max_media_attachments: Some(self.max_media_attachments),
-            characters_reserved_per_url: Some(self.characters_reserved_per_url),
+            max_characters: val.max_characters,
+            max_media_attachments: Some(val.max_media_attachments),
+            characters_reserved_per_url: Some(val.characters_reserved_per_url),
         }
     }
 }
 
-impl Into<MegalodonEntities::instance::Polls> for Polls {
-    fn into(self) -> MegalodonEntities::instance::Polls {
+impl From<Polls> for MegalodonEntities::instance::Polls {
+    fn from(val: Polls) -> Self {
         MegalodonEntities::instance::Polls {
-            max_options: self.max_options,
-            max_characters_per_option: self.max_characters_per_option,
-            min_expiration: self.min_expiration,
-            max_expiration: self.max_expiration,
+            max_options: val.max_options,
+            max_characters_per_option: val.max_characters_per_option,
+            min_expiration: val.min_expiration,
+            max_expiration: val.max_expiration,
         }
     }
 }
 
-impl Into<MegalodonEntities::instance::InstanceRule> for InstanceRule {
-    fn into(self) -> MegalodonEntities::instance::InstanceRule {
+impl From<InstanceRule> for MegalodonEntities::instance::InstanceRule {
+    fn from(val: InstanceRule) -> Self {
         MegalodonEntities::instance::InstanceRule {
-            id: self.id,
-            text: self.text,
+            id: val.id,
+            text: val.text,
         }
     }
 }

--- a/src/mastodon/entities/list.rs
+++ b/src/mastodon/entities/list.rs
@@ -16,9 +16,9 @@ pub enum RepliesPolicy {
     None,
 }
 
-impl Into<MegalodonEntities::list::RepliesPolicy> for RepliesPolicy {
-    fn into(self) -> MegalodonEntities::list::RepliesPolicy {
-        match self {
+impl From<RepliesPolicy> for MegalodonEntities::list::RepliesPolicy {
+    fn from(val: RepliesPolicy) -> Self {
+        match val {
             RepliesPolicy::Followed => MegalodonEntities::list::RepliesPolicy::Followed,
             RepliesPolicy::List => MegalodonEntities::list::RepliesPolicy::List,
             RepliesPolicy::None => MegalodonEntities::list::RepliesPolicy::None,
@@ -26,12 +26,12 @@ impl Into<MegalodonEntities::list::RepliesPolicy> for RepliesPolicy {
     }
 }
 
-impl Into<MegalodonEntities::List> for List {
-    fn into(self) -> MegalodonEntities::List {
+impl From<List> for MegalodonEntities::List {
+    fn from(val: List) -> Self {
         MegalodonEntities::List {
-            id: self.id,
-            title: self.title,
-            replies_policy: Some(self.replies_policy.into()),
+            id: val.id,
+            title: val.title,
+            replies_policy: Some(val.replies_policy.into()),
         }
     }
 }

--- a/src/mastodon/entities/marker.rs
+++ b/src/mastodon/entities/marker.rs
@@ -15,21 +15,21 @@ struct InnerMarker {
     updated_at: DateTime<Utc>,
 }
 
-impl Into<MegalodonEntities::Marker> for Marker {
-    fn into(self) -> MegalodonEntities::Marker {
+impl From<Marker> for MegalodonEntities::Marker {
+    fn from(val: Marker) -> Self {
         MegalodonEntities::Marker {
-            home: Some(self.home.into()),
-            notifications: Some(self.notifications.into()),
+            home: Some(val.home.into()),
+            notifications: Some(val.notifications.into()),
         }
     }
 }
 
-impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
-    fn into(self) -> MegalodonEntities::marker::InnerMarker {
+impl From<InnerMarker> for MegalodonEntities::marker::InnerMarker {
+    fn from(val: InnerMarker) -> Self {
         MegalodonEntities::marker::InnerMarker {
-            last_read_id: self.last_read_id,
-            version: self.version,
-            updated_at: self.updated_at,
+            last_read_id: val.last_read_id,
+            version: val.version,
+            updated_at: val.updated_at,
             unread_count: None,
         }
     }

--- a/src/mastodon/entities/mention.rs
+++ b/src/mastodon/entities/mention.rs
@@ -9,13 +9,13 @@ pub struct Mention {
     acct: String,
 }
 
-impl Into<MegalodonEntities::Mention> for Mention {
-    fn into(self) -> MegalodonEntities::Mention {
+impl From<Mention> for MegalodonEntities::Mention {
+    fn from(val: Mention) -> Self {
         MegalodonEntities::Mention {
-            id: self.id,
-            username: self.username,
-            url: self.url,
-            acct: self.acct,
+            id: val.id,
+            username: val.username,
+            url: val.url,
+            acct: val.acct,
         }
     }
 }

--- a/src/mastodon/entities/notification.rs
+++ b/src/mastodon/entities/notification.rs
@@ -29,9 +29,9 @@ pub enum NotificationType {
     AdminReport,
 }
 
-impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
-    fn into(self) -> MegalodonEntities::notification::NotificationType {
-        match self {
+impl From<NotificationType> for MegalodonEntities::notification::NotificationType {
+    fn from(val: NotificationType) -> Self {
+        match val {
             NotificationType::Follow => MegalodonEntities::notification::NotificationType::Follow,
             NotificationType::FollowRequest => {
                 MegalodonEntities::notification::NotificationType::FollowRequest
@@ -56,16 +56,16 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
     }
 }
 
-impl Into<MegalodonEntities::Notification> for Notification {
-    fn into(self) -> MegalodonEntities::Notification {
+impl From<Notification> for MegalodonEntities::Notification {
+    fn from(val: Notification) -> Self {
         MegalodonEntities::Notification {
-            account: Some(self.account.into()),
-            created_at: self.created_at,
-            id: self.id,
-            status: self.status.map(|i| i.into()),
+            account: Some(val.account.into()),
+            created_at: val.created_at,
+            id: val.id,
+            status: val.status.map(|i| i.into()),
             reaction: None,
             target: None,
-            r#type: self.r#type.into(),
+            r#type: val.r#type.into(),
         }
     }
 }

--- a/src/mastodon/entities/poll.rs
+++ b/src/mastodon/entities/poll.rs
@@ -16,18 +16,18 @@ pub struct Poll {
     emojis: Vec<Emoji>,
 }
 
-impl Into<MegalodonEntities::Poll> for Poll {
-    fn into(self) -> MegalodonEntities::Poll {
+impl From<Poll> for MegalodonEntities::Poll {
+    fn from(val: Poll) -> Self {
         MegalodonEntities::Poll {
-            id: self.id,
-            expires_at: self.expires_at,
-            expired: self.expired,
-            multiple: self.multiple,
-            votes_count: self.votes_count,
-            voters_count: self.voters_count,
-            options: self.options.into_iter().map(|i| i.into()).collect(),
-            voted: self.voted,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            expires_at: val.expires_at,
+            expired: val.expired,
+            multiple: val.multiple,
+            votes_count: val.votes_count,
+            voters_count: val.voters_count,
+            options: val.options.into_iter().map(|i| i.into()).collect(),
+            voted: val.voted,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/mastodon/entities/poll_option.rs
+++ b/src/mastodon/entities/poll_option.rs
@@ -7,11 +7,11 @@ pub struct PollOption {
     votes_count: Option<u32>,
 }
 
-impl Into<MegalodonEntities::PollOption> for PollOption {
-    fn into(self) -> MegalodonEntities::PollOption {
+impl From<PollOption> for MegalodonEntities::PollOption {
+    fn from(val: PollOption) -> Self {
         MegalodonEntities::PollOption {
-            title: self.title,
-            votes_count: self.votes_count,
+            title: val.title,
+            votes_count: val.votes_count,
         }
     }
 }

--- a/src/mastodon/entities/preferences.rs
+++ b/src/mastodon/entities/preferences.rs
@@ -199,21 +199,21 @@ impl<'de> de::Deserialize<'de> for Preferences {
     }
 }
 
-impl Into<MegalodonEntities::Preferences> for Preferences {
-    fn into(self) -> MegalodonEntities::Preferences {
+impl From<Preferences> for MegalodonEntities::Preferences {
+    fn from(val: Preferences) -> Self {
         MegalodonEntities::Preferences {
-            posting_default_visibility: self.posting_default_visibility.into(),
-            posting_default_sensitive: self.posting_default_sensitive.into(),
-            posting_default_language: self.posting_default_language.into(),
-            reading_expand_media: self.reading_expand_media.into(),
-            reading_expand_spoilers: self.reading_expand_spoilers.into(),
+            posting_default_visibility: val.posting_default_visibility.into(),
+            posting_default_sensitive: val.posting_default_sensitive.into(),
+            posting_default_language: val.posting_default_language.into(),
+            reading_expand_media: val.reading_expand_media.into(),
+            reading_expand_spoilers: val.reading_expand_spoilers.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::preferences::ExpandMedia> for ExpandMedia {
-    fn into(self) -> MegalodonEntities::preferences::ExpandMedia {
-        match self {
+impl From<ExpandMedia> for MegalodonEntities::preferences::ExpandMedia {
+    fn from(val: ExpandMedia) -> Self {
+        match val {
             ExpandMedia::Default => MegalodonEntities::preferences::ExpandMedia::Default,
             ExpandMedia::ShowAll => MegalodonEntities::preferences::ExpandMedia::ShowAll,
             ExpandMedia::HideAll => MegalodonEntities::preferences::ExpandMedia::HideAll,

--- a/src/mastodon/entities/push_subscription.rs
+++ b/src/mastodon/entities/push_subscription.rs
@@ -18,25 +18,25 @@ struct Alerts {
     poll: bool,
 }
 
-impl Into<MegalodonEntities::PushSubscription> for PushSubscription {
-    fn into(self) -> MegalodonEntities::PushSubscription {
+impl From<PushSubscription> for MegalodonEntities::PushSubscription {
+    fn from(val: PushSubscription) -> Self {
         MegalodonEntities::PushSubscription {
-            id: self.id,
-            endpoint: self.endpoint,
-            server_key: self.server_key,
-            alerts: self.alerts.into(),
+            id: val.id,
+            endpoint: val.endpoint,
+            server_key: val.server_key,
+            alerts: val.alerts.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::push_subscription::Alerts> for Alerts {
-    fn into(self) -> MegalodonEntities::push_subscription::Alerts {
+impl From<Alerts> for MegalodonEntities::push_subscription::Alerts {
+    fn from(val: Alerts) -> Self {
         MegalodonEntities::push_subscription::Alerts {
-            follow: self.follow,
-            favourite: self.favourite,
-            mention: self.mention,
-            reblog: self.reblog,
-            poll: self.poll,
+            follow: val.follow,
+            favourite: val.favourite,
+            mention: val.mention,
+            reblog: val.reblog,
+            poll: val.poll,
         }
     }
 }

--- a/src/mastodon/entities/relationship.rs
+++ b/src/mastodon/entities/relationship.rs
@@ -20,22 +20,22 @@ pub struct Relationship {
     languages: Option<String>,
 }
 
-impl Into<MegalodonEntities::Relationship> for Relationship {
-    fn into(self) -> MegalodonEntities::Relationship {
+impl From<Relationship> for MegalodonEntities::Relationship {
+    fn from(val: Relationship) -> Self {
         MegalodonEntities::Relationship {
-            id: self.id,
-            following: self.following,
-            followed_by: self.followed_by,
-            blocking: self.blocking,
-            blocked_by: self.blocked_by,
-            muting: self.muting,
-            muting_notifications: self.muting_notifications,
-            requested: self.requested,
-            domain_blocking: self.domain_blocking,
-            showing_reblogs: self.showing_reblogs,
-            endorsed: self.endorsed,
-            notifying: self.notifying,
-            note: Some(self.note),
+            id: val.id,
+            following: val.following,
+            followed_by: val.followed_by,
+            blocking: val.blocking,
+            blocked_by: val.blocked_by,
+            muting: val.muting,
+            muting_notifications: val.muting_notifications,
+            requested: val.requested,
+            domain_blocking: val.domain_blocking,
+            showing_reblogs: val.showing_reblogs,
+            endorsed: val.endorsed,
+            notifying: val.notifying,
+            note: Some(val.note),
         }
     }
 }

--- a/src/mastodon/entities/report.rs
+++ b/src/mastodon/entities/report.rs
@@ -24,9 +24,9 @@ pub enum Category {
     Other,
 }
 
-impl Into<MegalodonEntities::report::Category> for Category {
-    fn into(self) -> MegalodonEntities::report::Category {
-        match self {
+impl From<Category> for MegalodonEntities::report::Category {
+    fn from(val: Category) -> Self {
+        match val {
             Category::Spam => MegalodonEntities::report::Category::Spam,
             Category::Violation => MegalodonEntities::report::Category::Violation,
             Category::Other => MegalodonEntities::report::Category::Other,
@@ -34,18 +34,18 @@ impl Into<MegalodonEntities::report::Category> for Category {
     }
 }
 
-impl Into<MegalodonEntities::Report> for Report {
-    fn into(self) -> MegalodonEntities::Report {
+impl From<Report> for MegalodonEntities::Report {
+    fn from(val: Report) -> Self {
         MegalodonEntities::Report {
-            id: self.id,
-            action_taken: self.action_taken,
-            action_taken_at: self.action_taken_at,
-            category: Some(self.category.into()),
-            comment: Some(self.comment),
-            forwarded: Some(self.forwarded),
-            status_ids: self.status_ids,
-            rule_ids: self.rule_ids,
-            target_account: Some(self.target_account.into()),
+            id: val.id,
+            action_taken: val.action_taken,
+            action_taken_at: val.action_taken_at,
+            category: Some(val.category.into()),
+            comment: Some(val.comment),
+            forwarded: Some(val.forwarded),
+            status_ids: val.status_ids,
+            rule_ids: val.rule_ids,
+            target_account: Some(val.target_account.into()),
         }
     }
 }

--- a/src/mastodon/entities/results.rs
+++ b/src/mastodon/entities/results.rs
@@ -9,12 +9,12 @@ pub struct Results {
     hashtags: Vec<Tag>,
 }
 
-impl Into<MegalodonEntities::Results> for Results {
-    fn into(self) -> MegalodonEntities::Results {
+impl From<Results> for MegalodonEntities::Results {
+    fn from(val: Results) -> Self {
         MegalodonEntities::Results {
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            statuses: self.statuses.into_iter().map(|i| i.into()).collect(),
-            hashtags: self.hashtags.into_iter().map(|i| i.into()).collect(),
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            statuses: val.statuses.into_iter().map(|i| i.into()).collect(),
+            hashtags: val.hashtags.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/mastodon/entities/role.rs
+++ b/src/mastodon/entities/role.rs
@@ -12,8 +12,8 @@ impl From<MegalodonEntities::Role> for Role {
     }
 }
 
-impl Into<MegalodonEntities::Role> for Role {
-    fn into(self) -> MegalodonEntities::Role {
-        MegalodonEntities::Role { name: self.name }
+impl From<Role> for MegalodonEntities::Role {
+    fn from(val: Role) -> Self {
+        MegalodonEntities::Role { name: val.name }
     }
 }

--- a/src/mastodon/entities/scheduled_status.rs
+++ b/src/mastodon/entities/scheduled_status.rs
@@ -11,14 +11,14 @@ pub struct ScheduledStatus {
     media_attachments: Vec<Attachment>,
 }
 
-impl Into<MegalodonEntities::ScheduledStatus> for ScheduledStatus {
-    fn into(self) -> MegalodonEntities::ScheduledStatus {
+impl From<ScheduledStatus> for MegalodonEntities::ScheduledStatus {
+    fn from(val: ScheduledStatus) -> Self {
         MegalodonEntities::ScheduledStatus {
-            id: self.id,
-            scheduled_at: self.scheduled_at,
-            params: self.params.into(),
+            id: val.id,
+            scheduled_at: val.scheduled_at,
+            params: val.params.into(),
             media_attachments: Some(
-                self.media_attachments
+                val.media_attachments
                     .into_iter()
                     .map(|i| i.into())
                     .collect(),
@@ -27,8 +27,8 @@ impl Into<MegalodonEntities::ScheduledStatus> for ScheduledStatus {
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for ScheduledStatus {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::ScheduledStatus(self.into())
+impl From<ScheduledStatus> for megalodon::PostStatusOutput {
+    fn from(val: ScheduledStatus) -> Self {
+        megalodon::PostStatusOutput::ScheduledStatus(val.into())
     }
 }

--- a/src/mastodon/entities/source.rs
+++ b/src/mastodon/entities/source.rs
@@ -25,14 +25,14 @@ impl From<MegalodonEntities::Source> for Source {
     }
 }
 
-impl Into<MegalodonEntities::Source> for Source {
-    fn into(self) -> MegalodonEntities::Source {
+impl From<Source> for MegalodonEntities::Source {
+    fn from(val: Source) -> Self {
         MegalodonEntities::Source {
-            privacy: self.privacy,
-            sensitive: self.sensitive,
-            language: self.language,
-            note: self.note,
-            fields: self
+            privacy: val.privacy,
+            sensitive: val.sensitive,
+            language: val.language,
+            note: val.note,
+            fields: val
                 .fields
                 .map(|i| i.into_iter().map(|j| j.into()).collect()),
         }

--- a/src/mastodon/entities/stats.rs
+++ b/src/mastodon/entities/stats.rs
@@ -8,12 +8,12 @@ pub struct Stats {
     domain_count: u32,
 }
 
-impl Into<MegalodonEntities::Stats> for Stats {
-    fn into(self) -> MegalodonEntities::Stats {
+impl From<Stats> for MegalodonEntities::Stats {
+    fn from(val: Stats) -> Self {
         MegalodonEntities::Stats {
-            user_count: self.user_count,
-            status_count: self.status_count,
-            domain_count: self.domain_count,
+            user_count: val.user_count,
+            status_count: val.status_count,
+            domain_count: val.domain_count,
         }
     }
 }

--- a/src/mastodon/entities/status.rs
+++ b/src/mastodon/entities/status.rs
@@ -80,18 +80,19 @@ pub struct Tag {
     pub name: String,
     pub url: String,
 }
-impl Into<MegalodonEntities::status::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::status::Tag {
+
+impl From<Tag> for MegalodonEntities::status::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::status::Tag {
-            name: self.name,
-            url: self.url,
+            name: val.name,
+            url: val.url,
         }
     }
 }
 
-impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
-    fn into(self) -> MegalodonEntities::status::StatusVisibility {
-        match self {
+impl From<StatusVisibility> for MegalodonEntities::status::StatusVisibility {
+    fn from(val: StatusVisibility) -> Self {
+        match val {
             StatusVisibility::Public => MegalodonEntities::status::StatusVisibility::Public,
             StatusVisibility::Unlisted => MegalodonEntities::status::StatusVisibility::Unlisted,
             StatusVisibility::Private => MegalodonEntities::status::StatusVisibility::Private,
@@ -100,62 +101,62 @@ impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
     }
 }
 
-impl Into<MegalodonEntities::Status> for Status {
-    fn into(self) -> MegalodonEntities::Status {
+impl From<Status> for MegalodonEntities::Status {
+    fn from(val: Status) -> Self {
         let mut reblog_status: Option<Box<MegalodonEntities::Status>> = None;
         let mut quoted = false;
-        if let Some(reblog) = self.reblog {
+        if let Some(reblog) = val.reblog {
             let rs: Status = *reblog;
             reblog_status = Some(Box::new(rs.into()));
-        } else if let Some(quote) = self.quote {
+        } else if let Some(quote) = val.quote {
             let rs: Status = *quote;
             reblog_status = Some(Box::new(rs.into()));
             quoted = true;
         }
 
         MegalodonEntities::Status {
-            id: self.id,
-            uri: self.uri,
-            url: self.url,
-            account: self.account.into(),
-            in_reply_to_id: self.in_reply_to_id,
-            in_reply_to_account_id: self.in_reply_to_account_id,
+            id: val.id,
+            uri: val.uri,
+            url: val.url,
+            account: val.account.into(),
+            in_reply_to_id: val.in_reply_to_id,
+            in_reply_to_account_id: val.in_reply_to_account_id,
             reblog: reblog_status,
-            content: self.content,
+            content: val.content,
             plain_content: None,
-            created_at: self.created_at,
-            edited_at: self.edited_at,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            replies_count: self.replies_count,
-            reblogs_count: self.reblogs_count,
-            favourites_count: self.favourites_count,
-            reblogged: self.reblogged,
-            favourited: self.favourited,
-            muted: self.muted,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.into(),
-            media_attachments: self
+            created_at: val.created_at,
+            edited_at: val.edited_at,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            replies_count: val.replies_count,
+            reblogs_count: val.reblogs_count,
+            favourites_count: val.favourites_count,
+            reblogged: val.reblogged,
+            favourited: val.favourited,
+            muted: val.muted,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.into(),
+            media_attachments: val
                 .media_attachments
                 .into_iter()
                 .map(|i| i.into())
                 .collect(),
-            mentions: self.mentions.into_iter().map(|i| i.into()).collect(),
-            tags: self.tags.into_iter().map(|i| i.into()).collect(),
-            card: self.card.map(|i| i.into()),
-            poll: self.poll.map(|i| i.into()),
-            application: self.application.map(|i| i.into()),
-            language: self.language,
-            pinned: self.pinned,
+            mentions: val.mentions.into_iter().map(|i| i.into()).collect(),
+            tags: val.tags.into_iter().map(|i| i.into()).collect(),
+            card: val.card.map(|i| i.into()),
+            poll: val.poll.map(|i| i.into()),
+            application: val.application.map(|i| i.into()),
+            language: val.language,
+            pinned: val.pinned,
             emoji_reactions: None,
             quote: quoted,
-            bookmarked: self.bookmarked,
+            bookmarked: val.bookmarked,
         }
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for Status {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::Status(self.into())
+impl From<Status> for megalodon::PostStatusOutput {
+    fn from(val: Status) -> Self {
+        megalodon::PostStatusOutput::Status(val.into())
     }
 }

--- a/src/mastodon/entities/status_params.rs
+++ b/src/mastodon/entities/status_params.rs
@@ -15,17 +15,17 @@ pub struct StatusParams {
     application_id: u32,
 }
 
-impl Into<MegalodonEntities::StatusParams> for StatusParams {
-    fn into(self) -> MegalodonEntities::StatusParams {
+impl From<StatusParams> for MegalodonEntities::StatusParams {
+    fn from(val: StatusParams) -> Self {
         MegalodonEntities::StatusParams {
-            text: self.text,
-            in_reply_to_id: self.in_reply_to_id,
-            media_ids: self.media_ids,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.map(|i| i.into()),
-            scheduled_at: self.scheduled_at,
-            application_id: Some(self.application_id),
+            text: val.text,
+            in_reply_to_id: val.in_reply_to_id,
+            media_ids: val.media_ids,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.map(|i| i.into()),
+            scheduled_at: val.scheduled_at,
+            application_id: Some(val.application_id),
         }
     }
 }

--- a/src/mastodon/entities/status_source.rs
+++ b/src/mastodon/entities/status_source.rs
@@ -11,12 +11,12 @@ pub struct StatusSource {
     spoiler_text: String,
 }
 
-impl Into<MegalodonEntities::StatusSource> for StatusSource {
-    fn into(self) -> MegalodonEntities::StatusSource {
+impl From<StatusSource> for MegalodonEntities::StatusSource {
+    fn from(val: StatusSource) -> Self {
         MegalodonEntities::StatusSource {
-            id: self.id,
-            text: self.text,
-            spoiler_text: self.spoiler_text,
+            id: val.id,
+            text: val.text,
+            spoiler_text: val.spoiler_text,
         }
     }
 }

--- a/src/mastodon/entities/tag.rs
+++ b/src/mastodon/entities/tag.rs
@@ -10,13 +10,13 @@ pub struct Tag {
     following: Option<bool>,
 }
 
-impl Into<MegalodonEntities::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::Tag {
+impl From<Tag> for MegalodonEntities::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::Tag {
-            name: self.name,
-            url: self.url,
-            history: self.history.into_iter().map(|j| j.into()).collect(),
-            following: self.following,
+            name: val.name,
+            url: val.url,
+            history: val.history.into_iter().map(|j| j.into()).collect(),
+            following: val.following,
         }
     }
 }

--- a/src/mastodon/entities/token.rs
+++ b/src/mastodon/entities/token.rs
@@ -9,13 +9,13 @@ pub struct Token {
     created_at: u64,
 }
 
-impl Into<MegalodonEntities::Token> for Token {
-    fn into(self) -> MegalodonEntities::Token {
+impl From<Token> for MegalodonEntities::Token {
+    fn from(val: Token) -> Self {
         MegalodonEntities::Token {
-            access_token: self.access_token,
-            token_type: self.token_type,
-            scope: self.scope,
-            created_at: self.created_at,
+            access_token: val.access_token,
+            token_type: val.token_type,
+            scope: val.scope,
+            created_at: val.created_at,
         }
     }
 }

--- a/src/mastodon/entities/urls.rs
+++ b/src/mastodon/entities/urls.rs
@@ -6,10 +6,10 @@ pub struct URLs {
     streaming_api: String,
 }
 
-impl Into<MegalodonEntities::URLs> for URLs {
-    fn into(self) -> MegalodonEntities::URLs {
+impl From<URLs> for MegalodonEntities::URLs {
+    fn from(val: URLs) -> Self {
         MegalodonEntities::URLs {
-            streaming_api: self.streaming_api,
+            streaming_api: val.streaming_api,
         }
     }
 }

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -129,7 +129,7 @@ impl megalodon::Megalodon for Mastodon {
             .client
             .post::<oauth::AppDataFromServer>("/api/v1/apps", &params, None)
             .await?;
-        Ok(MegalodonOAuth::AppData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn fetch_access_token(
@@ -153,7 +153,7 @@ impl megalodon::Megalodon for Mastodon {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn refresh_access_token(
@@ -175,7 +175,7 @@ impl megalodon::Megalodon for Mastodon {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn revoke_access_token(
@@ -1451,7 +1451,6 @@ impl megalodon::Megalodon for Mastodon {
                 );
             }
             if let Some(scheduled_at) = options.scheduled_at {
-
                 // https://docs.joinmastodon.org/methods/statuses/#form-data-parameters
                 // scheduled_at must be at least 5 mins in the futur
                 if scheduled_at.sub(Utc::now()).num_minutes() > 5 {
@@ -1514,7 +1513,10 @@ impl megalodon::Megalodon for Mastodon {
         ))
     }
 
-    async fn get_status_source(&self, id: String) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
+    async fn get_status_source(
+        &self,
+        id: String,
+    ) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
         let res = self
             .client
             .get::<entities::StatusSource>(format!("/api/v1/statuses/{}/source", id).as_str(), None)
@@ -1576,7 +1578,12 @@ impl megalodon::Megalodon for Mastodon {
 
     async fn delete_status(&self, id: String) -> Result<Response<()>, Error> {
         let params = HashMap::new();
-        let Response { json: _, status, status_text, header } = self
+        let Response {
+            json: _,
+            status,
+            status_text,
+            header,
+        } = self
             .client
             .delete::<Value>(format!("/api/v1/statuses/{}", id).as_str(), &params, None)
             .await?;

--- a/src/mastodon/oauth.rs
+++ b/src/mastodon/oauth.rs
@@ -20,26 +20,26 @@ pub struct TokenDataFromServer {
     created_at: u64,
 }
 
-impl Into<oauth::AppData> for AppDataFromServer {
-    fn into(self) -> oauth::AppData {
+impl From<AppDataFromServer> for oauth::AppData {
+    fn from(val: AppDataFromServer) -> Self {
         oauth::AppData::new(
-            self.id,
-            self.name,
-            self.website,
-            Some(self.redirect_uri),
-            self.client_id,
-            self.client_secret,
+            val.id,
+            val.name,
+            val.website,
+            Some(val.redirect_uri),
+            val.client_id,
+            val.client_secret,
         )
     }
 }
 
-impl Into<oauth::TokenData> for TokenDataFromServer {
-    fn into(self) -> oauth::TokenData {
+impl From<TokenDataFromServer> for oauth::TokenData {
+    fn from(val: TokenDataFromServer) -> Self {
         oauth::TokenData::new(
-            self.access_token,
-            self.token_type,
-            Some(self.scope),
-            Some(self.created_at),
+            val.access_token,
+            val.token_type,
+            Some(val.scope),
+            Some(val.created_at),
             None,
             None,
         )

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -364,7 +364,10 @@ pub trait Megalodon {
     async fn get_status(&self, id: String) -> Result<Response<entities::Status>, Error>;
 
     /// Obtain the source properties for a status so that it can be edited.
-    async fn get_status_source(&self, id: String) -> Result<Response<entities::StatusSource>, Error>;
+    async fn get_status_source(
+        &self,
+        id: String,
+    ) -> Result<Response<entities::StatusSource>, Error>;
 
     /// Edit a status.
     async fn edit_status(

--- a/src/pleroma/entities/account.rs
+++ b/src/pleroma/entities/account.rs
@@ -67,47 +67,47 @@ impl From<MegalodonEntities::Account> for Account {
     }
 }
 
-impl Into<MegalodonEntities::Account> for Account {
-    fn into(self) -> MegalodonEntities::Account {
+impl From<Account> for MegalodonEntities::Account {
+    fn from(val: Account) -> Self {
         let mut moved_account: Option<Box<MegalodonEntities::Account>> = None;
-        if let Some(moved) = self.moved {
+        if let Some(moved) = val.moved {
             let ma: Account = *moved;
             moved_account = Some(Box::new(ma.into()));
         }
         MegalodonEntities::Account {
-            id: self.id,
-            username: self.username,
-            acct: self.acct,
-            display_name: self.display_name,
-            locked: self.locked,
-            discoverable: self.discoverable,
+            id: val.id,
+            username: val.username,
+            acct: val.acct,
+            display_name: val.display_name,
+            locked: val.locked,
+            discoverable: val.discoverable,
             group: None,
-            noindex: self.noindex,
-            suspended: self.suspended,
-            limited: self.limited,
-            created_at: self.created_at,
-            followers_count: self.followers_count,
-            following_count: self.following_count,
-            statuses_count: self.statuses_count,
-            note: self.note,
-            url: self.url,
-            avatar: self.avatar,
-            avatar_static: self.avatar_static,
-            header: self.header,
-            header_static: self.header_static,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            noindex: val.noindex,
+            suspended: val.suspended,
+            limited: val.limited,
+            created_at: val.created_at,
+            followers_count: val.followers_count,
+            following_count: val.following_count,
+            statuses_count: val.statuses_count,
+            note: val.note,
+            url: val.url,
+            avatar: val.avatar,
+            avatar_static: val.avatar_static,
+            header: val.header,
+            header_static: val.header_static,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
             moved: moved_account,
-            fields: self.fields.into_iter().map(|j| j.into()).collect(),
-            bot: self.bot,
-            source: self.source.map(|i| i.into()),
+            fields: val.fields.into_iter().map(|j| j.into()).collect(),
+            bot: val.bot,
+            source: val.source.map(|i| i.into()),
             role: None,
             mute_expires_at: None,
         }
     }
 }
 
-impl Into<megalodon::FollowRequestOutput> for Account {
-    fn into(self) -> megalodon::FollowRequestOutput {
-        megalodon::FollowRequestOutput::Account(self.into())
+impl From<Account> for megalodon::FollowRequestOutput {
+    fn from(val: Account) -> Self {
+        megalodon::FollowRequestOutput::Account(val.into())
     }
 }

--- a/src/pleroma/entities/activity.rs
+++ b/src/pleroma/entities/activity.rs
@@ -9,13 +9,13 @@ pub struct Activity {
     registrations: String,
 }
 
-impl Into<MegalodonEntities::Activity> for Activity {
-    fn into(self) -> MegalodonEntities::Activity {
+impl From<Activity> for MegalodonEntities::Activity {
+    fn from(val: Activity) -> Self {
         MegalodonEntities::Activity {
-            week: self.week,
-            statuses: self.statuses,
-            logins: self.logins,
-            registrations: self.registrations,
+            week: val.week,
+            statuses: val.statuses,
+            logins: val.logins,
+            registrations: val.registrations,
         }
     }
 }

--- a/src/pleroma/entities/announcement.rs
+++ b/src/pleroma/entities/announcement.rs
@@ -43,55 +43,55 @@ pub struct Reaction {
     static_url: Option<String>,
 }
 
-impl Into<MegalodonEntities::Announcement> for Announcement {
-    fn into(self) -> MegalodonEntities::Announcement {
+impl From<Announcement> for MegalodonEntities::Announcement {
+    fn from(val: Announcement) -> Self {
         MegalodonEntities::Announcement {
-            id: self.id,
-            content: self.content,
-            starts_at: self.starts_at,
-            ends_at: self.ends_at,
-            published: self.published,
-            all_day: self.all_day,
-            published_at: self.published_at,
-            updated_at: Some(self.updated_at),
+            id: val.id,
+            content: val.content,
+            starts_at: val.starts_at,
+            ends_at: val.ends_at,
+            published: val.published,
+            all_day: val.all_day,
+            published_at: val.published_at,
+            updated_at: Some(val.updated_at),
             read: None,
-            mentions: self.mentions.into_iter().map(|i| i.into()).collect(),
-            statuses: self.statuses.into_iter().map(|i| i.into()).collect(),
-            tags: self.tags.into_iter().map(|i| i.into()).collect(),
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            reactions: self.reactions.into_iter().map(|i| i.into()).collect(),
+            mentions: val.mentions.into_iter().map(|i| i.into()).collect(),
+            statuses: val.statuses.into_iter().map(|i| i.into()).collect(),
+            tags: val.tags.into_iter().map(|i| i.into()).collect(),
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            reactions: val.reactions.into_iter().map(|i| i.into()).collect(),
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Account> for Account {
-    fn into(self) -> MegalodonEntities::announcement::Account {
+impl From<Account> for MegalodonEntities::announcement::Account {
+    fn from(val: Account) -> Self {
         MegalodonEntities::announcement::Account {
-            id: self.id,
-            username: self.username,
-            url: self.url,
-            acct: self.acct,
+            id: val.id,
+            username: val.username,
+            url: val.url,
+            acct: val.acct,
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Status> for Status {
-    fn into(self) -> MegalodonEntities::announcement::Status {
+impl From<Status> for MegalodonEntities::announcement::Status {
+    fn from(val: Status) -> Self {
         MegalodonEntities::announcement::Status {
-            id: self.id,
-            url: self.url,
+            id: val.id,
+            url: val.url,
         }
     }
 }
 
-impl Into<MegalodonEntities::announcement::Reaction> for Reaction {
-    fn into(self) -> MegalodonEntities::announcement::Reaction {
+impl From<Reaction> for MegalodonEntities::announcement::Reaction {
+    fn from(val: Reaction) -> Self {
         MegalodonEntities::announcement::Reaction {
-            name: self.name,
-            count: self.count,
-            me: self.me,
-            url: self.url,
-            static_url: self.static_url,
+            name: val.name,
+            count: val.count,
+            me: val.me,
+            url: val.url,
+            static_url: val.static_url,
         }
     }
 }

--- a/src/pleroma/entities/application.rs
+++ b/src/pleroma/entities/application.rs
@@ -8,12 +8,12 @@ pub struct Application {
     vapid_key: Option<String>,
 }
 
-impl Into<MegalodonEntities::Application> for Application {
-    fn into(self) -> MegalodonEntities::Application {
+impl From<Application> for MegalodonEntities::Application {
+    fn from(val: Application) -> Self {
         MegalodonEntities::Application {
-            name: self.name,
-            website: self.website,
-            vapid_key: self.vapid_key,
+            name: val.name,
+            website: val.website,
+            vapid_key: val.vapid_key,
         }
     }
 }

--- a/src/pleroma/entities/attachment.rs
+++ b/src/pleroma/entities/attachment.rs
@@ -63,9 +63,9 @@ pub enum AttachmentType {
     Unknown,
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentType {
-        match self {
+impl From<AttachmentType> for MegalodonEntities::attachment::AttachmentType {
+    fn from(val: AttachmentType) -> Self {
+        match val {
             AttachmentType::Image => MegalodonEntities::attachment::AttachmentType::Image,
             AttachmentType::Gifv => MegalodonEntities::attachment::AttachmentType::Gifv,
             AttachmentType::Video => MegalodonEntities::attachment::AttachmentType::Video,
@@ -75,61 +75,58 @@ impl Into<MegalodonEntities::attachment::AttachmentType> for AttachmentType {
     }
 }
 
-impl Into<MegalodonEntities::Attachment> for Attachment {
-    fn into(self) -> MegalodonEntities::Attachment {
+impl From<Attachment> for MegalodonEntities::Attachment {
+    fn from(val: Attachment) -> Self {
         MegalodonEntities::Attachment {
-            id: self.id,
-            r#type: self.r#type.into(),
-            url: self.url,
-            remote_url: self.remote_url,
-            preview_url: self.preview_url,
-            text_url: self.text_url,
-            meta: self.meta.map(|i| i.into()),
-            description: self.description,
-            blurhash: self.blurhash,
+            id: val.id,
+            r#type: val.r#type.into(),
+            url: val.url,
+            remote_url: val.remote_url,
+            preview_url: val.preview_url,
+            text_url: val.text_url,
+            meta: val.meta.map(|i| i.into()),
+            description: val.description,
+            blurhash: val.blurhash,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::AttachmentMeta> for AttachmentMeta {
-    fn into(self) -> MegalodonEntities::attachment::AttachmentMeta {
+impl From<AttachmentMeta> for MegalodonEntities::attachment::AttachmentMeta {
+    fn from(val: AttachmentMeta) -> Self {
         MegalodonEntities::attachment::AttachmentMeta {
-            original: self.original.map(|i| i.into()),
-            small: self.small.map(|i| i.into()),
-            focus: self.focus.map(|i| i.into()),
-            length: self.length,
-            duration: self.duration,
-            fps: self.fps,
-            size: self.size,
-            width: self.width,
-            height: self.height,
-            aspect: self.aspect,
-            audio_encode: self.audio_encode,
-            audio_bitrate: self.audio_bitrate,
-            audio_channel: self.audio_channel,
+            original: val.original.map(|i| i.into()),
+            small: val.small.map(|i| i.into()),
+            focus: val.focus.map(|i| i.into()),
+            length: val.length,
+            duration: val.duration,
+            fps: val.fps,
+            size: val.size,
+            width: val.width,
+            height: val.height,
+            aspect: val.aspect,
+            audio_encode: val.audio_encode,
+            audio_bitrate: val.audio_bitrate,
+            audio_channel: val.audio_channel,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::MetaSub> for MetaSub {
-    fn into(self) -> MegalodonEntities::attachment::MetaSub {
+impl From<MetaSub> for MegalodonEntities::attachment::MetaSub {
+    fn from(val: MetaSub) -> Self {
         MegalodonEntities::attachment::MetaSub {
-            width: self.width,
-            height: self.height,
-            size: self.size,
-            aspect: self.aspect,
-            frame_rate: self.frame_rate,
-            duration: self.duration,
-            bitrate: self.bitrate,
+            width: val.width,
+            height: val.height,
+            size: val.size,
+            aspect: val.aspect,
+            frame_rate: val.frame_rate,
+            duration: val.duration,
+            bitrate: val.bitrate,
         }
     }
 }
 
-impl Into<MegalodonEntities::attachment::Focus> for Focus {
-    fn into(self) -> MegalodonEntities::attachment::Focus {
-        MegalodonEntities::attachment::Focus {
-            x: self.x,
-            y: self.y,
-        }
+impl From<Focus> for MegalodonEntities::attachment::Focus {
+    fn from(val: Focus) -> Self {
+        MegalodonEntities::attachment::Focus { x: val.x, y: val.y }
     }
 }

--- a/src/pleroma/entities/card.rs
+++ b/src/pleroma/entities/card.rs
@@ -21,9 +21,9 @@ pub enum CardType {
     Rich,
 }
 
-impl Into<MegalodonEntities::card::CardType> for CardType {
-    fn into(self) -> MegalodonEntities::card::CardType {
-        match self {
+impl From<CardType> for MegalodonEntities::card::CardType {
+    fn from(val: CardType) -> Self {
+        match val {
             CardType::Link => MegalodonEntities::card::CardType::Link,
             CardType::Photo => MegalodonEntities::card::CardType::Photo,
             CardType::Video => MegalodonEntities::card::CardType::Video,
@@ -32,18 +32,18 @@ impl Into<MegalodonEntities::card::CardType> for CardType {
     }
 }
 
-impl Into<MegalodonEntities::Card> for Card {
-    fn into(self) -> MegalodonEntities::Card {
+impl From<Card> for MegalodonEntities::Card {
+    fn from(val: Card) -> Self {
         MegalodonEntities::Card {
-            url: self.url,
-            title: self.title,
-            description: self.description,
-            r#type: self.r#type.into(),
-            image: self.image,
+            url: val.url,
+            title: val.title,
+            description: val.description,
+            r#type: val.r#type.into(),
+            image: val.image,
             author_name: None,
             author_url: None,
-            provider_name: self.provider_name,
-            provider_url: self.provider_url,
+            provider_name: val.provider_name,
+            provider_url: val.provider_url,
             html: None,
             width: None,
             height: None,

--- a/src/pleroma/entities/context.rs
+++ b/src/pleroma/entities/context.rs
@@ -8,11 +8,11 @@ pub struct Context {
     descendants: Vec<Status>,
 }
 
-impl Into<MegalodonEntities::Context> for Context {
-    fn into(self) -> MegalodonEntities::Context {
+impl From<Context> for MegalodonEntities::Context {
+    fn from(val: Context) -> Self {
         MegalodonEntities::Context {
-            ancestors: self.ancestors.into_iter().map(|i| i.into()).collect(),
-            descendants: self.descendants.into_iter().map(|i| i.into()).collect(),
+            ancestors: val.ancestors.into_iter().map(|i| i.into()).collect(),
+            descendants: val.descendants.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/pleroma/entities/conversation.rs
+++ b/src/pleroma/entities/conversation.rs
@@ -10,13 +10,13 @@ pub struct Conversation {
     unread: bool,
 }
 
-impl Into<MegalodonEntities::Conversation> for Conversation {
-    fn into(self) -> MegalodonEntities::Conversation {
+impl From<Conversation> for MegalodonEntities::Conversation {
+    fn from(val: Conversation) -> Self {
         MegalodonEntities::Conversation {
-            id: self.id,
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            last_status: self.last_status.map(|i| i.into()),
-            unread: self.unread,
+            id: val.id,
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            last_status: val.last_status.map(|i| i.into()),
+            unread: val.unread,
         }
     }
 }

--- a/src/pleroma/entities/emoji.rs
+++ b/src/pleroma/entities/emoji.rs
@@ -20,13 +20,13 @@ impl From<MegalodonEntities::Emoji> for Emoji {
     }
 }
 
-impl Into<MegalodonEntities::Emoji> for Emoji {
-    fn into(self) -> MegalodonEntities::Emoji {
+impl From<Emoji> for MegalodonEntities::Emoji {
+    fn from(val: Emoji) -> Self {
         MegalodonEntities::Emoji {
-            shortcode: self.shortcode,
-            static_url: self.static_url,
-            url: self.url,
-            visible_in_picker: self.visible_in_picker,
+            shortcode: val.shortcode,
+            static_url: val.static_url,
+            url: val.url,
+            visible_in_picker: val.visible_in_picker,
             category: None,
         }
     }

--- a/src/pleroma/entities/featured_tag.rs
+++ b/src/pleroma/entities/featured_tag.rs
@@ -10,13 +10,13 @@ pub struct FeaturedTag {
     last_status_at: DateTime<Utc>,
 }
 
-impl Into<MegalodonEntities::FeaturedTag> for FeaturedTag {
-    fn into(self) -> MegalodonEntities::FeaturedTag {
+impl From<FeaturedTag> for MegalodonEntities::FeaturedTag {
+    fn from(val: FeaturedTag) -> Self {
         MegalodonEntities::FeaturedTag {
-            id: self.id,
-            name: self.name,
-            statuses_count: self.statuses_count,
-            last_status_at: self.last_status_at,
+            id: val.id,
+            name: val.name,
+            statuses_count: val.statuses_count,
+            last_status_at: val.last_status_at,
         }
     }
 }

--- a/src/pleroma/entities/field.rs
+++ b/src/pleroma/entities/field.rs
@@ -19,12 +19,12 @@ impl From<MegalodonEntities::Field> for Field {
     }
 }
 
-impl Into<MegalodonEntities::Field> for Field {
-    fn into(self) -> MegalodonEntities::Field {
+impl From<Field> for MegalodonEntities::Field {
+    fn from(val: Field) -> Self {
         MegalodonEntities::Field {
-            name: self.name,
-            value: self.value,
-            verified_at: self.verified_at,
+            name: val.name,
+            value: val.value,
+            verified_at: val.verified_at,
             verified: None,
         }
     }

--- a/src/pleroma/entities/filter.rs
+++ b/src/pleroma/entities/filter.rs
@@ -21,9 +21,9 @@ pub enum FilterContext {
     Thread,
 }
 
-impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
-    fn into(self) -> MegalodonEntities::filter::FilterContext {
-        match self {
+impl From<FilterContext> for MegalodonEntities::filter::FilterContext {
+    fn from(val: FilterContext) -> Self {
+        match val {
             FilterContext::Home => MegalodonEntities::filter::FilterContext::Home,
             FilterContext::Notifications => MegalodonEntities::filter::FilterContext::Notifications,
             FilterContext::Public => MegalodonEntities::filter::FilterContext::Public,
@@ -32,15 +32,15 @@ impl Into<MegalodonEntities::filter::FilterContext> for FilterContext {
     }
 }
 
-impl Into<MegalodonEntities::Filter> for Filter {
-    fn into(self) -> MegalodonEntities::Filter {
+impl From<Filter> for MegalodonEntities::Filter {
+    fn from(val: Filter) -> Self {
         MegalodonEntities::Filter {
-            id: self.id,
-            phrase: self.phrase,
-            context: self.context.into_iter().map(|i| i.into()).collect(),
-            expires_at: self.expires_at,
-            irreversible: self.irreversible,
-            whole_word: self.whole_word,
+            id: val.id,
+            phrase: val.phrase,
+            context: val.context.into_iter().map(|i| i.into()).collect(),
+            expires_at: val.expires_at,
+            irreversible: val.irreversible,
+            whole_word: val.whole_word,
         }
     }
 }

--- a/src/pleroma/entities/history.rs
+++ b/src/pleroma/entities/history.rs
@@ -11,12 +11,12 @@ pub struct History {
     accounts: usize,
 }
 
-impl Into<MegalodonEntities::History> for History {
-    fn into(self) -> MegalodonEntities::History {
+impl From<History> for MegalodonEntities::History {
+    fn from(val: History) -> Self {
         MegalodonEntities::History {
-            day: self.day,
-            uses: self.uses,
-            accounts: self.accounts,
+            day: val.day,
+            uses: val.uses,
+            accounts: val.accounts,
         }
     }
 }

--- a/src/pleroma/entities/identity_proof.rs
+++ b/src/pleroma/entities/identity_proof.rs
@@ -11,14 +11,14 @@ pub struct IdentityProof {
     profile_url: String,
 }
 
-impl Into<MegalodonEntities::IdentityProof> for IdentityProof {
-    fn into(self) -> MegalodonEntities::IdentityProof {
+impl From<IdentityProof> for MegalodonEntities::IdentityProof {
+    fn from(val: IdentityProof) -> Self {
         MegalodonEntities::IdentityProof {
-            provider: self.provider,
-            provider_username: self.provider_username,
-            updated_at: self.updated_at,
-            proof_url: self.proof_url,
-            profile_url: self.profile_url,
+            provider: val.provider,
+            provider_username: val.provider_username,
+            updated_at: val.updated_at,
+            proof_url: val.proof_url,
+            profile_url: val.profile_url,
         }
     }
 }

--- a/src/pleroma/entities/instance.rs
+++ b/src/pleroma/entities/instance.rs
@@ -59,32 +59,32 @@ pub struct PollLimits {
     pub max_options: u32,
 }
 
-impl Into<MegalodonEntities::Instance> for Instance {
-    fn into(self) -> MegalodonEntities::Instance {
+impl From<Instance> for MegalodonEntities::Instance {
+    fn from(val: Instance) -> Self {
         MegalodonEntities::Instance {
-            uri: self.uri,
-            title: self.title,
-            description: self.description,
-            email: self.email,
-            version: self.version,
-            thumbnail: self.thumbnail,
-            urls: Some(self.urls.into()),
-            stats: self.stats.into(),
-            languages: self.languages,
-            registrations: self.registrations,
-            approval_required: self.approval_required,
+            uri: val.uri,
+            title: val.title,
+            description: val.description,
+            email: val.email,
+            version: val.version,
+            thumbnail: val.thumbnail,
+            urls: Some(val.urls.into()),
+            stats: val.stats.into(),
+            languages: val.languages,
+            registrations: val.registrations,
+            approval_required: val.approval_required,
             invites_enabled: None,
             configuration: MegalodonEntities::instance::InstanceConfig {
                 statuses: MegalodonEntities::instance::Statuses {
-                    max_characters: self.max_toot_chars,
-                    max_media_attachments: self.max_media_attachments,
+                    max_characters: val.max_toot_chars,
+                    max_media_attachments: val.max_media_attachments,
                     characters_reserved_per_url: None,
                 },
                 polls: Some(MegalodonEntities::instance::Polls {
-                    max_options: self.poll_limits.max_options,
-                    max_characters_per_option: self.poll_limits.max_option_chars,
-                    min_expiration: self.poll_limits.min_expiration,
-                    max_expiration: self.poll_limits.max_expiration,
+                    max_options: val.poll_limits.max_options,
+                    max_characters_per_option: val.poll_limits.max_option_chars,
+                    min_expiration: val.poll_limits.min_expiration,
+                    max_expiration: val.poll_limits.max_expiration,
                 }),
             },
             contact_account: None,

--- a/src/pleroma/entities/list.rs
+++ b/src/pleroma/entities/list.rs
@@ -7,11 +7,11 @@ pub struct List {
     title: String,
 }
 
-impl Into<MegalodonEntities::List> for List {
-    fn into(self) -> MegalodonEntities::List {
+impl From<List> for MegalodonEntities::List {
+    fn from(val: List) -> Self {
         MegalodonEntities::List {
-            id: self.id,
-            title: self.title,
+            id: val.id,
+            title: val.title,
             replies_policy: None,
         }
     }

--- a/src/pleroma/entities/marker.rs
+++ b/src/pleroma/entities/marker.rs
@@ -21,22 +21,22 @@ struct PleromaMarker {
     unread_count: u32,
 }
 
-impl Into<MegalodonEntities::Marker> for Marker {
-    fn into(self) -> MegalodonEntities::Marker {
+impl From<Marker> for MegalodonEntities::Marker {
+    fn from(val: Marker) -> Self {
         MegalodonEntities::Marker {
             home: None,
-            notifications: Some(self.notifications.into()),
+            notifications: Some(val.notifications.into()),
         }
     }
 }
 
-impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
-    fn into(self) -> MegalodonEntities::marker::InnerMarker {
+impl From<InnerMarker> for MegalodonEntities::marker::InnerMarker {
+    fn from(val: InnerMarker) -> Self {
         MegalodonEntities::marker::InnerMarker {
-            last_read_id: self.last_read_id,
-            version: self.version,
-            updated_at: self.updated_at,
-            unread_count: Some(self.pleroma.unread_count),
+            last_read_id: val.last_read_id,
+            version: val.version,
+            updated_at: val.updated_at,
+            unread_count: Some(val.pleroma.unread_count),
         }
     }
 }

--- a/src/pleroma/entities/mention.rs
+++ b/src/pleroma/entities/mention.rs
@@ -9,13 +9,13 @@ pub struct Mention {
     acct: String,
 }
 
-impl Into<MegalodonEntities::Mention> for Mention {
-    fn into(self) -> MegalodonEntities::Mention {
+impl From<Mention> for MegalodonEntities::Mention {
+    fn from(val: Mention) -> Self {
         MegalodonEntities::Mention {
-            id: self.id,
-            username: self.username,
-            url: self.url,
-            acct: self.acct,
+            id: val.id,
+            username: val.username,
+            url: val.url,
+            acct: val.acct,
         }
     }
 }

--- a/src/pleroma/entities/notification.rs
+++ b/src/pleroma/entities/notification.rs
@@ -104,9 +104,9 @@ impl<'de> de::Deserialize<'de> for NotificationType {
     }
 }
 
-impl Into<MegalodonEntities::notification::NotificationType> for NotificationType {
-    fn into(self) -> MegalodonEntities::notification::NotificationType {
-        match self {
+impl From<NotificationType> for MegalodonEntities::notification::NotificationType {
+    fn from(val: NotificationType) -> Self {
+        match val {
             NotificationType::Follow => MegalodonEntities::notification::NotificationType::Follow,
             NotificationType::FollowRequest => {
                 MegalodonEntities::notification::NotificationType::FollowRequest
@@ -128,17 +128,17 @@ impl Into<MegalodonEntities::notification::NotificationType> for NotificationTyp
     }
 }
 
-impl Into<MegalodonEntities::Notification> for Notification {
-    fn into(self) -> MegalodonEntities::Notification {
-        let reaction = self.clone().map_reaction();
+impl From<Notification> for MegalodonEntities::Notification {
+    fn from(val: Notification) -> Self {
+        let reaction = val.clone().map_reaction();
         MegalodonEntities::Notification {
-            account: Some(self.account.into()),
-            created_at: self.created_at,
-            id: self.id,
-            status: self.status.map(|i| i.into()),
+            account: Some(val.account.into()),
+            created_at: val.created_at,
+            id: val.id,
+            status: val.status.map(|i| i.into()),
             reaction: reaction.map(|i| i.into()),
-            target: self.target.map(|i| i.into()),
-            r#type: self.r#type.into(),
+            target: val.target.map(|i| i.into()),
+            r#type: val.r#type.into(),
         }
     }
 }

--- a/src/pleroma/entities/poll.rs
+++ b/src/pleroma/entities/poll.rs
@@ -16,18 +16,18 @@ pub struct Poll {
     emojis: Vec<Emoji>,
 }
 
-impl Into<MegalodonEntities::Poll> for Poll {
-    fn into(self) -> MegalodonEntities::Poll {
+impl From<Poll> for MegalodonEntities::Poll {
+    fn from(val: Poll) -> Self {
         MegalodonEntities::Poll {
-            id: self.id,
-            expires_at: self.expires_at,
-            expired: self.expired,
-            multiple: self.multiple,
-            votes_count: self.votes_count,
-            voters_count: self.voters_count,
-            options: self.options.into_iter().map(|i| i.into()).collect(),
-            voted: self.voted,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
+            id: val.id,
+            expires_at: val.expires_at,
+            expired: val.expired,
+            multiple: val.multiple,
+            votes_count: val.votes_count,
+            voters_count: val.voters_count,
+            options: val.options.into_iter().map(|i| i.into()).collect(),
+            voted: val.voted,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/pleroma/entities/poll_option.rs
+++ b/src/pleroma/entities/poll_option.rs
@@ -7,11 +7,11 @@ pub struct PollOption {
     votes_count: Option<u32>,
 }
 
-impl Into<MegalodonEntities::PollOption> for PollOption {
-    fn into(self) -> MegalodonEntities::PollOption {
+impl From<PollOption> for MegalodonEntities::PollOption {
+    fn from(val: PollOption) -> Self {
         MegalodonEntities::PollOption {
-            title: self.title,
-            votes_count: self.votes_count,
+            title: val.title,
+            votes_count: val.votes_count,
         }
     }
 }

--- a/src/pleroma/entities/preferences.rs
+++ b/src/pleroma/entities/preferences.rs
@@ -199,21 +199,21 @@ impl<'de> de::Deserialize<'de> for Preferences {
     }
 }
 
-impl Into<MegalodonEntities::Preferences> for Preferences {
-    fn into(self) -> MegalodonEntities::Preferences {
+impl From<Preferences> for MegalodonEntities::Preferences {
+    fn from(val: Preferences) -> Self {
         MegalodonEntities::Preferences {
-            posting_default_visibility: self.posting_default_visibility.into(),
-            posting_default_sensitive: self.posting_default_sensitive.into(),
-            posting_default_language: self.posting_default_language.into(),
-            reading_expand_media: self.reading_expand_media.into(),
-            reading_expand_spoilers: self.reading_expand_spoilers.into(),
+            posting_default_visibility: val.posting_default_visibility.into(),
+            posting_default_sensitive: val.posting_default_sensitive.into(),
+            posting_default_language: val.posting_default_language.into(),
+            reading_expand_media: val.reading_expand_media.into(),
+            reading_expand_spoilers: val.reading_expand_spoilers.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::preferences::ExpandMedia> for ExpandMedia {
-    fn into(self) -> MegalodonEntities::preferences::ExpandMedia {
-        match self {
+impl From<ExpandMedia> for MegalodonEntities::preferences::ExpandMedia {
+    fn from(val: ExpandMedia) -> Self {
+        match val {
             ExpandMedia::Default => MegalodonEntities::preferences::ExpandMedia::Default,
             ExpandMedia::ShowAll => MegalodonEntities::preferences::ExpandMedia::ShowAll,
             ExpandMedia::HideAll => MegalodonEntities::preferences::ExpandMedia::HideAll,

--- a/src/pleroma/entities/push_subscription.rs
+++ b/src/pleroma/entities/push_subscription.rs
@@ -18,25 +18,25 @@ struct Alerts {
     poll: bool,
 }
 
-impl Into<MegalodonEntities::PushSubscription> for PushSubscription {
-    fn into(self) -> MegalodonEntities::PushSubscription {
+impl From<PushSubscription> for MegalodonEntities::PushSubscription {
+    fn from(val: PushSubscription) -> Self {
         MegalodonEntities::PushSubscription {
-            id: self.id,
-            endpoint: self.endpoint,
-            server_key: self.server_key,
-            alerts: self.alerts.into(),
+            id: val.id,
+            endpoint: val.endpoint,
+            server_key: val.server_key,
+            alerts: val.alerts.into(),
         }
     }
 }
 
-impl Into<MegalodonEntities::push_subscription::Alerts> for Alerts {
-    fn into(self) -> MegalodonEntities::push_subscription::Alerts {
+impl From<Alerts> for MegalodonEntities::push_subscription::Alerts {
+    fn from(val: Alerts) -> Self {
         MegalodonEntities::push_subscription::Alerts {
-            follow: self.follow,
-            favourite: self.favourite,
-            mention: self.mention,
-            reblog: self.reblog,
-            poll: self.poll,
+            follow: val.follow,
+            favourite: val.favourite,
+            mention: val.mention,
+            reblog: val.reblog,
+            poll: val.poll,
         }
     }
 }

--- a/src/pleroma/entities/reaction.rs
+++ b/src/pleroma/entities/reaction.rs
@@ -12,16 +12,16 @@ pub struct Reaction {
     pub url: Option<String>,
 }
 
-impl Into<MegalodonEntities::Reaction> for Reaction {
-    fn into(self) -> MegalodonEntities::Reaction {
+impl From<Reaction> for MegalodonEntities::Reaction {
+    fn from(val: Reaction) -> Self {
         MegalodonEntities::Reaction {
-            count: self.count,
-            me: self.me,
-            name: self.name,
-            url: self.url.clone(),
-            static_url: self.url,
-            account_ids: self.account_ids,
-            accounts: self
+            count: val.count,
+            me: val.me,
+            name: val.name,
+            url: val.url.clone(),
+            static_url: val.url,
+            account_ids: val.account_ids,
+            accounts: val
                 .accounts
                 .clone()
                 .map(|i| i.into_iter().map(|a| a.into()).collect()),

--- a/src/pleroma/entities/relationship.rs
+++ b/src/pleroma/entities/relationship.rs
@@ -20,22 +20,22 @@ pub struct Relationship {
     note: String,
 }
 
-impl Into<MegalodonEntities::Relationship> for Relationship {
-    fn into(self) -> MegalodonEntities::Relationship {
+impl From<Relationship> for MegalodonEntities::Relationship {
+    fn from(val: Relationship) -> Self {
         MegalodonEntities::Relationship {
-            id: self.id,
-            following: self.following,
-            followed_by: self.followed_by,
-            blocking: self.blocking,
-            blocked_by: self.blocked_by,
-            muting: self.muting,
-            muting_notifications: self.muting_notifications,
-            requested: self.requested,
-            domain_blocking: self.domain_blocking,
-            showing_reblogs: self.showing_reblogs,
-            endorsed: self.endorsed,
-            notifying: self.notifying,
-            note: Some(self.note),
+            id: val.id,
+            following: val.following,
+            followed_by: val.followed_by,
+            blocking: val.blocking,
+            blocked_by: val.blocked_by,
+            muting: val.muting,
+            muting_notifications: val.muting_notifications,
+            requested: val.requested,
+            domain_blocking: val.domain_blocking,
+            showing_reblogs: val.showing_reblogs,
+            endorsed: val.endorsed,
+            notifying: val.notifying,
+            note: Some(val.note),
         }
     }
 }

--- a/src/pleroma/entities/report.rs
+++ b/src/pleroma/entities/report.rs
@@ -7,11 +7,11 @@ pub struct Report {
     pub action_taken: bool,
 }
 
-impl Into<MegalodonEntities::Report> for Report {
-    fn into(self) -> MegalodonEntities::Report {
+impl From<Report> for MegalodonEntities::Report {
+    fn from(val: Report) -> Self {
         MegalodonEntities::Report {
-            id: self.id,
-            action_taken: self.action_taken,
+            id: val.id,
+            action_taken: val.action_taken,
             action_taken_at: None,
             category: None,
             comment: None,

--- a/src/pleroma/entities/results.rs
+++ b/src/pleroma/entities/results.rs
@@ -9,12 +9,12 @@ pub struct Results {
     hashtags: Vec<Tag>,
 }
 
-impl Into<MegalodonEntities::Results> for Results {
-    fn into(self) -> MegalodonEntities::Results {
+impl From<Results> for MegalodonEntities::Results {
+    fn from(val: Results) -> Self {
         MegalodonEntities::Results {
-            accounts: self.accounts.into_iter().map(|i| i.into()).collect(),
-            statuses: self.statuses.into_iter().map(|i| i.into()).collect(),
-            hashtags: self.hashtags.into_iter().map(|i| i.into()).collect(),
+            accounts: val.accounts.into_iter().map(|i| i.into()).collect(),
+            statuses: val.statuses.into_iter().map(|i| i.into()).collect(),
+            hashtags: val.hashtags.into_iter().map(|i| i.into()).collect(),
         }
     }
 }

--- a/src/pleroma/entities/scheduled_status.rs
+++ b/src/pleroma/entities/scheduled_status.rs
@@ -11,21 +11,21 @@ pub struct ScheduledStatus {
     media_attachments: Option<Vec<Attachment>>,
 }
 
-impl Into<MegalodonEntities::ScheduledStatus> for ScheduledStatus {
-    fn into(self) -> MegalodonEntities::ScheduledStatus {
+impl From<ScheduledStatus> for MegalodonEntities::ScheduledStatus {
+    fn from(val: ScheduledStatus) -> Self {
         MegalodonEntities::ScheduledStatus {
-            id: self.id,
-            scheduled_at: self.scheduled_at,
-            params: self.params.into(),
-            media_attachments: self
+            id: val.id,
+            scheduled_at: val.scheduled_at,
+            params: val.params.into(),
+            media_attachments: val
                 .media_attachments
                 .map(|m| m.into_iter().map(|i| i.into()).collect()),
         }
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for ScheduledStatus {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::ScheduledStatus(self.into())
+impl From<ScheduledStatus> for megalodon::PostStatusOutput {
+    fn from(val: ScheduledStatus) -> Self {
+        megalodon::PostStatusOutput::ScheduledStatus(val.into())
     }
 }

--- a/src/pleroma/entities/source.rs
+++ b/src/pleroma/entities/source.rs
@@ -25,14 +25,14 @@ impl From<MegalodonEntities::Source> for Source {
     }
 }
 
-impl Into<MegalodonEntities::Source> for Source {
-    fn into(self) -> MegalodonEntities::Source {
+impl From<Source> for MegalodonEntities::Source {
+    fn from(val: Source) -> Self {
         MegalodonEntities::Source {
-            privacy: self.privacy,
-            sensitive: self.sensitive,
-            language: self.language,
-            note: self.note,
-            fields: self
+            privacy: val.privacy,
+            sensitive: val.sensitive,
+            language: val.language,
+            note: val.note,
+            fields: val
                 .fields
                 .map(|i| i.into_iter().map(|j| j.into()).collect()),
         }

--- a/src/pleroma/entities/stats.rs
+++ b/src/pleroma/entities/stats.rs
@@ -8,12 +8,12 @@ pub struct Stats {
     domain_count: u32,
 }
 
-impl Into<MegalodonEntities::Stats> for Stats {
-    fn into(self) -> MegalodonEntities::Stats {
+impl From<Stats> for MegalodonEntities::Stats {
+    fn from(val: Stats) -> Self {
         MegalodonEntities::Stats {
-            user_count: self.user_count,
-            status_count: self.status_count,
-            domain_count: self.domain_count,
+            user_count: val.user_count,
+            status_count: val.status_count,
+            domain_count: val.domain_count,
         }
     }
 }

--- a/src/pleroma/entities/status.rs
+++ b/src/pleroma/entities/status.rs
@@ -66,9 +66,9 @@ pub struct PleromaContent {
     pub text_plain: String,
 }
 
-impl Into<MegalodonEntities::status::StatusVisibility> for StatusVisibility {
-    fn into(self) -> MegalodonEntities::status::StatusVisibility {
-        match self {
+impl From<StatusVisibility> for MegalodonEntities::status::StatusVisibility {
+    fn from(val: StatusVisibility) -> Self {
+        match val {
             StatusVisibility::Public => MegalodonEntities::status::StatusVisibility::Public,
             StatusVisibility::Unlisted => MegalodonEntities::status::StatusVisibility::Unlisted,
             StatusVisibility::Private => MegalodonEntities::status::StatusVisibility::Private,
@@ -83,74 +83,74 @@ pub struct Tag {
     pub url: String,
 }
 
-impl Into<MegalodonEntities::status::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::status::Tag {
+impl From<Tag> for MegalodonEntities::status::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::status::Tag {
-            name: self.name,
-            url: self.url,
+            name: val.name,
+            url: val.url,
         }
     }
 }
 
-impl Into<MegalodonEntities::Status> for Status {
-    fn into(self) -> MegalodonEntities::Status {
+impl From<Status> for MegalodonEntities::Status {
+    fn from(val: Status) -> Self {
         let mut reblog_status: Option<Box<MegalodonEntities::Status>> = None;
         let mut quoted = false;
-        if let Some(reblog) = self.reblog {
+        if let Some(reblog) = val.reblog {
             let rs: Status = *reblog;
-            if rs.content != self.content {
+            if rs.content != val.content {
                 quoted = true;
             }
             reblog_status = Some(Box::new(rs.into()));
         }
 
         MegalodonEntities::Status {
-            id: self.id,
-            uri: self.uri,
-            url: self.url,
-            account: self.account.into(),
-            in_reply_to_id: self.in_reply_to_id,
-            in_reply_to_account_id: self.in_reply_to_account_id,
+            id: val.id,
+            uri: val.uri,
+            url: val.url,
+            account: val.account.into(),
+            in_reply_to_id: val.in_reply_to_id,
+            in_reply_to_account_id: val.in_reply_to_account_id,
             reblog: reblog_status,
-            content: self.content,
-            plain_content: self.pleroma.content.map(|c| c.text_plain),
-            created_at: self.created_at,
-            edited_at: self.edited_at,
-            emojis: self.emojis.into_iter().map(|i| i.into()).collect(),
-            replies_count: self.replies_count,
-            reblogs_count: self.reblogs_count,
-            favourites_count: self.favourites_count,
-            reblogged: self.reblogged,
-            favourited: self.favourited,
-            muted: self.muted,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.into(),
-            media_attachments: self
+            content: val.content,
+            plain_content: val.pleroma.content.map(|c| c.text_plain),
+            created_at: val.created_at,
+            edited_at: val.edited_at,
+            emojis: val.emojis.into_iter().map(|i| i.into()).collect(),
+            replies_count: val.replies_count,
+            reblogs_count: val.reblogs_count,
+            favourites_count: val.favourites_count,
+            reblogged: val.reblogged,
+            favourited: val.favourited,
+            muted: val.muted,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.into(),
+            media_attachments: val
                 .media_attachments
                 .into_iter()
                 .map(|i| i.into())
                 .collect(),
-            mentions: self.mentions.into_iter().map(|i| i.into()).collect(),
-            tags: self.tags.into_iter().map(|i| i.into()).collect(),
-            card: self.card.map(|i| i.into()),
-            poll: self.poll.map(|i| i.into()),
-            application: self.application.map(|i| i.into()),
-            language: self.language,
-            pinned: self.pinned,
-            emoji_reactions: self
+            mentions: val.mentions.into_iter().map(|i| i.into()).collect(),
+            tags: val.tags.into_iter().map(|i| i.into()).collect(),
+            card: val.card.map(|i| i.into()),
+            poll: val.poll.map(|i| i.into()),
+            application: val.application.map(|i| i.into()),
+            language: val.language,
+            pinned: val.pinned,
+            emoji_reactions: val
                 .pleroma
                 .emoji_reactions
                 .map(|v| v.into_iter().map(|e| e.into()).collect()),
             quote: quoted,
-            bookmarked: self.bookmarked,
+            bookmarked: val.bookmarked,
         }
     }
 }
 
-impl Into<megalodon::PostStatusOutput> for Status {
-    fn into(self) -> megalodon::PostStatusOutput {
-        megalodon::PostStatusOutput::Status(self.into())
+impl From<Status> for megalodon::PostStatusOutput {
+    fn from(val: Status) -> Self {
+        megalodon::PostStatusOutput::Status(val.into())
     }
 }
 

--- a/src/pleroma/entities/status_params.rs
+++ b/src/pleroma/entities/status_params.rs
@@ -14,16 +14,16 @@ pub struct StatusParams {
     scheduled_at: Option<DateTime<Utc>>,
 }
 
-impl Into<MegalodonEntities::StatusParams> for StatusParams {
-    fn into(self) -> MegalodonEntities::StatusParams {
+impl From<StatusParams> for MegalodonEntities::StatusParams {
+    fn from(val: StatusParams) -> Self {
         MegalodonEntities::StatusParams {
-            text: self.text,
-            in_reply_to_id: self.in_reply_to_id,
-            media_ids: self.media_ids,
-            sensitive: self.sensitive,
-            spoiler_text: self.spoiler_text,
-            visibility: self.visibility.map(|i| i.into()),
-            scheduled_at: self.scheduled_at,
+            text: val.text,
+            in_reply_to_id: val.in_reply_to_id,
+            media_ids: val.media_ids,
+            sensitive: val.sensitive,
+            spoiler_text: val.spoiler_text,
+            visibility: val.visibility.map(|i| i.into()),
+            scheduled_at: val.scheduled_at,
             application_id: None,
         }
     }

--- a/src/pleroma/entities/status_source.rs
+++ b/src/pleroma/entities/status_source.rs
@@ -11,12 +11,12 @@ pub struct StatusSource {
     spoiler_text: String,
 }
 
-impl Into<MegalodonEntities::StatusSource> for StatusSource {
-    fn into(self) -> MegalodonEntities::StatusSource {
+impl From<StatusSource> for MegalodonEntities::StatusSource {
+    fn from(val: StatusSource) -> Self {
         MegalodonEntities::StatusSource {
-            id: self.id,
-            text: self.text,
-            spoiler_text: self.spoiler_text,
+            id: val.id,
+            text: val.text,
+            spoiler_text: val.spoiler_text,
         }
     }
 }

--- a/src/pleroma/entities/tag.rs
+++ b/src/pleroma/entities/tag.rs
@@ -10,13 +10,13 @@ pub struct Tag {
     following: Option<bool>,
 }
 
-impl Into<MegalodonEntities::Tag> for Tag {
-    fn into(self) -> MegalodonEntities::Tag {
+impl From<Tag> for MegalodonEntities::Tag {
+    fn from(val: Tag) -> Self {
         MegalodonEntities::Tag {
-            name: self.name,
-            url: self.url,
-            history: self.history.into_iter().map(|j| j.into()).collect(),
-            following: self.following,
+            name: val.name,
+            url: val.url,
+            history: val.history.into_iter().map(|j| j.into()).collect(),
+            following: val.following,
         }
     }
 }

--- a/src/pleroma/entities/token.rs
+++ b/src/pleroma/entities/token.rs
@@ -9,13 +9,13 @@ pub struct Token {
     created_at: u64,
 }
 
-impl Into<MegalodonEntities::Token> for Token {
-    fn into(self) -> MegalodonEntities::Token {
+impl From<Token> for MegalodonEntities::Token {
+    fn from(val: Token) -> Self {
         MegalodonEntities::Token {
-            access_token: self.access_token,
-            token_type: self.token_type,
-            scope: self.scope,
-            created_at: self.created_at,
+            access_token: val.access_token,
+            token_type: val.token_type,
+            scope: val.scope,
+            created_at: val.created_at,
         }
     }
 }

--- a/src/pleroma/entities/urls.rs
+++ b/src/pleroma/entities/urls.rs
@@ -6,10 +6,10 @@ pub struct URLs {
     streaming_api: String,
 }
 
-impl Into<MegalodonEntities::URLs> for URLs {
-    fn into(self) -> MegalodonEntities::URLs {
+impl From<URLs> for MegalodonEntities::URLs {
+    fn from(val: URLs) -> Self {
         MegalodonEntities::URLs {
-            streaming_api: self.streaming_api,
+            streaming_api: val.streaming_api,
         }
     }
 }

--- a/src/pleroma/oauth.rs
+++ b/src/pleroma/oauth.rs
@@ -22,28 +22,28 @@ pub struct TokenDataFromServer {
     refresh_token: Option<String>,
 }
 
-impl Into<oauth::AppData> for AppDataFromServer {
-    fn into(self) -> oauth::AppData {
+impl From<AppDataFromServer> for oauth::AppData {
+    fn from(val: AppDataFromServer) -> Self {
         oauth::AppData::new(
-            self.id,
-            self.name,
-            self.website,
-            Some(self.redirect_uri),
-            self.client_id,
-            self.client_secret,
+            val.id,
+            val.name,
+            val.website,
+            Some(val.redirect_uri),
+            val.client_id,
+            val.client_secret,
         )
     }
 }
 
-impl Into<oauth::TokenData> for TokenDataFromServer {
-    fn into(self) -> oauth::TokenData {
+impl From<TokenDataFromServer> for oauth::TokenData {
+    fn from(val: TokenDataFromServer) -> Self {
         oauth::TokenData::new(
-            self.access_token,
-            self.token_type,
-            Some(self.scope),
-            Some(self.created_at),
-            self.expires_in,
-            self.refresh_token,
+            val.access_token,
+            val.token_type,
+            Some(val.scope),
+            Some(val.created_at),
+            val.expires_in,
+            val.refresh_token,
         )
     }
 }

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -122,7 +122,7 @@ impl megalodon::Megalodon for Pleroma {
             .client
             .post::<oauth::AppDataFromServer>("/api/v1/apps", &params, None)
             .await?;
-        Ok(MegalodonOAuth::AppData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn fetch_access_token(
@@ -146,7 +146,7 @@ impl megalodon::Megalodon for Pleroma {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn refresh_access_token(
@@ -168,7 +168,7 @@ impl megalodon::Megalodon for Pleroma {
             .client
             .post::<oauth::TokenDataFromServer>("/oauth/token", &params, None)
             .await?;
-        Ok(MegalodonOAuth::TokenData::from(res.json.into()))
+        Ok(res.json.into())
     }
 
     async fn revoke_access_token(
@@ -1430,7 +1430,10 @@ impl megalodon::Megalodon for Pleroma {
         ))
     }
 
-    async fn get_status_source(&self, id: String) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
+    async fn get_status_source(
+        &self,
+        id: String,
+    ) -> Result<Response<MegalodonEntities::StatusSource>, Error> {
         let res = self
             .client
             .get::<entities::StatusSource>(format!("/api/v1/statuses/{}/source", id).as_str(), None)


### PR DESCRIPTION
refactor: implement from instead of Into

https://doc.rust-lang.org/std/convert/trait.Into.html
> One should avoid implementing Into and implement From instead.
> Implementing From automatically provides one with an implementation of
> Into thanks to the blanket implementation in the standard library.