### PR TITLE
cleanup warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ rustls-tls = [
 ]
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = ">=0.4.25", features = ["serde"] }
 async-trait = "0.1.77"
-reqwest = { version = "0.11", features = [
+reqwest = { version = ">=0.11.2", features = [
     "json",
     "multipart",
     "stream",
 ], default-features = false }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = ">=1.28.0", features = ["full"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }
@@ -42,10 +42,10 @@ sha1 = { version = "0.10" }
 hex = { version = "0.4" }
 tokio-tungstenite = { version = "0.21" }
 urlencoding = { version = "2.1" }
-thiserror = "1"
-futures-util = "0.3"
+thiserror = ">=1.0.23"
+futures-util = ">=0.3.28"
 rand = "0.8"
-regex = "1"
+regex = ">=1.3.0"
 uuid = { version = "1.7", features = ["v4"] }
 tracing = "0.1.40"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,29 +25,29 @@ rustls-tls = [
 ]
 
 [dependencies]
-chrono = { version = ">=0.4.25", features = ["serde"] }
 async-trait = "0.1.77"
+chrono = { version = ">=0.4.25", features = ["serde"] }
+futures-util = ">=0.3.28"
+hex = { version = "0.4" }
+oauth2 = { version = "4.4" }
+rand = "0.8"
+regex = ">=1.3.0"
 reqwest = { version = ">=0.11.2", features = [
     "json",
     "multipart",
     "stream",
 ], default-features = false }
-tokio = { version = ">=1.28.0", features = ["full"] }
-tokio-util = { version = "0.7.10", features = ["codec"] }
-serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }
-url = "2.5.0"
-oauth2 = { version = "4.4" }
+serde_json = "1.0.114"
 sha1 = { version = "0.10" }
-hex = { version = "0.4" }
-tokio-tungstenite = { version = "0.21" }
-urlencoding = { version = "2.1" }
 thiserror = ">=1.0.23"
-futures-util = ">=0.3.28"
-rand = "0.8"
-regex = ">=1.3.0"
-uuid = { version = "1.7", features = ["v4"] }
+tokio = { version = ">=1.28.0", features = ["full"] }
+tokio-tungstenite = { version = "0.21" }
+tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = "0.1.40"
+url = "2.5.0"
+urlencoding = { version = "2.1" }
+uuid = { version = "1.7", features = ["v4"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/friendica_post_with_schedule.rs
+++ b/examples/friendica_post_with_schedule.rs
@@ -18,7 +18,7 @@ async fn main() {
 
     let client = generator(megalodon::SNS::Friendica, url, Some(token), None);
 
-    let scheduled_at = Utc::now() + Duration::minutes(6);
+    let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);
 
     match post_status(&client, "Test", scheduled_at).await {

--- a/examples/mastodon_post_with_schedule.rs
+++ b/examples/mastodon_post_with_schedule.rs
@@ -18,7 +18,7 @@ async fn main() {
 
     let client = generator(megalodon::SNS::Mastodon, url, Some(token), None);
 
-    let scheduled_at = Utc::now() + Duration::minutes(6);
+    let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);
 
     match post_status(&client, "Test", scheduled_at).await {

--- a/examples/pleroma_post_with_schedule.rs
+++ b/examples/pleroma_post_with_schedule.rs
@@ -18,7 +18,7 @@ async fn main() {
 
     let client = generator(megalodon::SNS::Pleroma, url, Some(token), None);
 
-    let scheduled_at = Utc::now() + Duration::minutes(6);
+    let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);
 
     match post_status(&client, "Test", scheduled_at).await {

--- a/src/firefish/entities/mod.rs
+++ b/src/firefish/entities/mod.rs
@@ -27,6 +27,7 @@ pub mod user_detail;
 
 pub use account::Account;
 pub use announcement::Announcement;
+#[allow(unused_imports)]
 pub use app::App;
 pub use blocking::Blocking;
 pub use created_note::CreatedNote;
@@ -43,10 +44,13 @@ pub use meta::Meta;
 pub use mute::Mute;
 pub use note::Note;
 pub use notification::Notification;
+#[allow(unused_imports)]
 pub use poll::Poll;
+#[allow(unused_imports)]
 pub use reaction::Reaction;
 pub use relation::Relation;
 pub use session::Session;
+#[allow(unused_imports)]
 pub use stats::Stats;
 pub use user::User;
 pub use user_detail::UserDetail;

--- a/src/friendica/entities/mod.rs
+++ b/src/friendica/entities/mod.rs
@@ -34,6 +34,7 @@ pub mod token;
 pub mod urls;
 
 pub use account::Account;
+#[allow(unused_imports)]
 pub use activity::Activity;
 pub use application::Application;
 pub use attachment::Attachment;
@@ -41,6 +42,7 @@ pub use card::Card;
 pub use context::Context;
 pub use conversation::Conversation;
 pub use emoji::Emoji;
+#[allow(unused_imports)]
 pub use featured_tag::FeaturedTag;
 pub use field::Field;
 pub use filter::Filter;
@@ -49,6 +51,7 @@ pub use history::History;
 pub use identity_proof::IdentityProof;
 pub use instance::Instance;
 pub use list::List;
+#[allow(unused_imports)]
 pub use marker::Marker;
 pub use mention::Mention;
 pub use notification::Notification;
@@ -57,6 +60,7 @@ pub use poll_option::PollOption;
 pub use preferences::Preferences;
 pub use push_subscription::PushSubscription;
 pub use relationship::Relationship;
+#[allow(unused_imports)]
 pub use report::Report;
 pub use results::Results;
 pub use scheduled_status::ScheduledStatus;
@@ -65,5 +69,6 @@ pub use stats::Stats;
 pub use status::{Status, StatusVisibility};
 pub use status_params::StatusParams;
 pub use tag::Tag;
+#[allow(unused_imports)]
 pub use token::Token;
 pub use urls::URLs;

--- a/src/pleroma/entities/marker.rs
+++ b/src/pleroma/entities/marker.rs
@@ -42,7 +42,7 @@ impl Into<MegalodonEntities::marker::InnerMarker> for InnerMarker {
 }
 
 mod date_format_without_tz {
-    use chrono::{DateTime, TimeZone, Utc};
+    use chrono::{DateTime, NaiveDateTime, Utc};
     use serde::{self, Deserialize, Deserializer, Serializer};
 
     const FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S";
@@ -60,7 +60,42 @@ mod date_format_without_tz {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Utc.datetime_from_str(&s, FORMAT)
+        NaiveDateTime::parse_from_str(&s, FORMAT)
             .map_err(serde::de::Error::custom)
+            .map(|naive| naive.and_utc())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_marker_() {
+        let data = r#"{
+            "notifications": {
+                "last_read_id": "1",
+                "version": 2,
+                "updated_at": "2020-01-02T03:04:05",
+                "pleroma": {
+                    "unread_count": 3
+                }
+            }
+        }"#;
+        let marker: Marker = serde_json::from_str(data).unwrap();
+        assert_eq!(marker.notifications.last_read_id, "1");
+        assert_eq!(marker.notifications.version, 2);
+        assert_eq!(
+            marker.notifications.updated_at.to_string(),
+            "2020-01-02 03:04:05 UTC"
+        );
+        assert_eq!(marker.notifications.pleroma.unread_count, 3);
+
+        let serialized = serde_json::to_string(&marker).unwrap();
+
+        assert_eq!(
+            serialized,
+            r#"{"notifications":{"last_read_id":"1","version":2,"updated_at":"2020-01-02T03:04:05","pleroma":{"unread_count":3}}}"#
+        );
     }
 }


### PR DESCRIPTION
This addresses the problems in #209 and #207 which were due to versions of crates that were specified at the 0.x level when various features were actually introduced in 0.x.y.

E.g.
- the and_utc() method was introduced in chrono 0.4.25
- the IntoUrl trait was implemented on String in reqwest 0.11.2
- env_filter requires regex >=1.3.0 (because the perf feature was added in that version)
- tungstenite and tokio-tungstenite require thiserror ^1.0.23
- tokio-util requires tokio 1.28
- tokio-tungstenite required log 0.4.8 and futures-util 0.3.28
- etc.

Commits:
- **Update minimal crate versions**
- **Reapply "fix: cleanup warnings"**
