### PR TITLE
Switch followers_count to i32 to accept negative values

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -16,7 +16,7 @@ pub struct Account {
     pub suspended: Option<bool>,
     pub limited: Option<bool>,
     pub created_at: DateTime<Utc>,
-    pub followers_count: u32,
+    pub followers_count: i32,
     pub following_count: u32,
     pub statuses_count: u32,
     pub note: String,

--- a/src/entities/follow_request.rs
+++ b/src/entities/follow_request.rs
@@ -19,7 +19,7 @@ pub struct FollowRequest {
     pub avatar_static: String,
     pub header: String,
     pub header_static: String,
-    pub followers_count: u32,
+    pub followers_count: i32,
     pub following_count: u32,
     pub statuses_count: u32,
     pub emojis: Vec<Emoji>,

--- a/src/firefish/entities/account.rs
+++ b/src/firefish/entities/account.rs
@@ -12,7 +12,7 @@ pub struct Account {
     display_name: String,
     locked: bool,
     created_at: DateTime<Utc>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     note: String,

--- a/src/firefish/entities/user_detail.rs
+++ b/src/firefish/entities/user_detail.rs
@@ -41,7 +41,7 @@ pub struct UserDetail {
     // birthday: Option<String>,
     pub lang: Option<String>,
     fields: Vec<Field>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     notes_count: u32,
     // pinned_note_ids: Vec<String>,

--- a/src/friendica/entities/account.rs
+++ b/src/friendica/entities/account.rs
@@ -13,7 +13,7 @@ pub struct Account {
     discoverable: Option<bool>,
     group: bool,
     created_at: DateTime<Utc>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     note: String,

--- a/src/friendica/entities/follow_request.rs
+++ b/src/friendica/entities/follow_request.rs
@@ -20,7 +20,7 @@ pub struct FollowRequest {
     avatar_static: String,
     header: String,
     header_static: String,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     emojis: Vec<Emoji>,

--- a/src/gotosocial/entities/account.rs
+++ b/src/gotosocial/entities/account.rs
@@ -12,7 +12,7 @@ pub struct Account {
     locked: bool,
     discoverable: Option<bool>,
     created_at: DateTime<Utc>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     note: String,

--- a/src/mastodon/entities/account.rs
+++ b/src/mastodon/entities/account.rs
@@ -17,7 +17,7 @@ pub struct Account {
     suspended: Option<bool>,
     limited: Option<bool>,
     created_at: DateTime<Utc>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     note: String,

--- a/src/pleroma/entities/account.rs
+++ b/src/pleroma/entities/account.rs
@@ -16,7 +16,7 @@ pub struct Account {
     suspended: Option<bool>,
     limited: Option<bool>,
     created_at: DateTime<Utc>,
-    followers_count: u32,
+    followers_count: i32,
     following_count: u32,
     statuses_count: u32,
     note: String,


### PR DESCRIPTION
Switching from `u32` to `i32` seems to fix the parsing failure when encountering a negative `followers_count`. I only saw the problem on Mastodon, so maybe this is overkill?

fixes https://github.com/h3poteto/megalodon-rs/issues/221