### PR TITLE
Fix spelling of `markers` in API URL

### DIFF
--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -2551,7 +2551,7 @@ impl megalodon::Megalodon for Pleroma {
         }
         let res = self
             .client
-            .post::<entities::Marker>("/api/v1/makers", &params, None)
+            .post::<entities::Marker>("/api/v1/markers", &params, None)
             .await?;
 
         Ok(Response::<MegalodonEntities::Marker>::new(


### PR DESCRIPTION
Really small fix but it should make the API work on Pleroma, it currently 404s