### PR TITLE
Add set_account_note to Mastodon and GoToSocial

### DIFF
--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -808,6 +808,19 @@ impl megalodon::Megalodon for Firefish {
         ))
     }
 
+    async fn set_account_note(
+        &self,
+        _id: String,
+        _note: Option<String>,
+    ) -> Result<Response<MegalodonEntities::Relationship>, Error> {
+        Err(Error::new_own(
+            "Firefish does not support".to_string(),
+            error::Kind::NoImplementedError,
+            None,
+            None,
+        ))
+    }
+
     async fn get_relationships(
         &self,
         ids: Vec<String>,

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -638,6 +638,19 @@ impl megalodon::Megalodon for Friendica {
         ))
     }
 
+    async fn set_account_note(
+        &self,
+        _id: String,
+        _note: Option<String>,
+    ) -> Result<Response<MegalodonEntities::Relationship>, Error> {
+        Err(Error::new_own(
+            "Friendica does not support".to_string(),
+            error::Kind::NoImplementedError,
+            None,
+            None,
+        ))
+    }
+
     async fn get_relationships(
         &self,
         ids: Vec<String>,

--- a/src/gotosocial/gotosocial.rs
+++ b/src/gotosocial/gotosocial.rs
@@ -678,6 +678,32 @@ impl megalodon::Megalodon for Gotosocial {
         ))
     }
 
+    async fn set_account_note(
+        &self,
+        id: String,
+        note: Option<String>,
+    ) -> Result<Response<MegalodonEntities::Relationship>, Error> {
+        let params = HashMap::<&str, Value>::from([(
+            "comment",
+            serde_json::Value::String(note.unwrap_or("".to_string())),
+        )]);
+        let res = self
+            .client
+            .post::<entities::Relationship>(
+                format!("/api/v1/accounts/{}/note", id).as_ref(),
+                &params,
+                None,
+            )
+            .await?;
+
+        Ok(Response::<MegalodonEntities::Relationship>::new(
+            res.json.into(),
+            res.status,
+            res.status_text,
+            res.header,
+        ))
+    }
+
     async fn get_relationships(
         &self,
         ids: Vec<String>,

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -734,6 +734,32 @@ impl megalodon::Megalodon for Mastodon {
         ))
     }
 
+    async fn set_account_note(
+        &self,
+        id: String,
+        note: Option<String>,
+    ) -> Result<Response<MegalodonEntities::Relationship>, Error> {
+        let params = HashMap::<&str, Value>::from([(
+            "comment",
+            serde_json::Value::String(note.unwrap_or("".to_string())),
+        )]);
+        let res = self
+            .client
+            .post::<entities::Relationship>(
+                format!("/api/v1/accounts/{}/note", id).as_ref(),
+                &params,
+                None,
+            )
+            .await?;
+
+        Ok(Response::<MegalodonEntities::Relationship>::new(
+            res.json.into(),
+            res.status,
+            res.status_text,
+            res.header,
+        ))
+    }
+
     async fn get_relationships(
         &self,
         ids: Vec<String>,

--- a/src/megalodon.rs
+++ b/src/megalodon.rs
@@ -173,6 +173,9 @@ pub trait Megalodon {
     /// Remove the given account from the user's featured profiles.
     async fn unpin_account(&self, id: String) -> Result<Response<entities::Relationship>, Error>;
 
+    /// Set a private note on the given account.
+    async fn set_account_note(&self, id: String, note: Option<String>) -> Result<Response<entities::Relationship>, Error>;
+
     /// Find out whether a given account is followed, blocked, muted, etc.
     async fn get_relationships(
         &self,

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -742,6 +742,19 @@ impl megalodon::Megalodon for Pleroma {
         ))
     }
 
+    async fn set_account_note(
+        &self,
+        _id: String,
+        _note: Option<String>,
+    ) -> Result<Response<MegalodonEntities::Relationship>, Error> {
+        Err(Error::new_own(
+            "Pleroma does not support".to_string(),
+            error::Kind::NoImplementedError,
+            None,
+            None,
+        ))
+    }
+
     async fn get_relationships(
         &self,
         ids: Vec<String>,


### PR DESCRIPTION
This pull request adds a helper to allow setting a private note on a Mastodon or GoToSocial account