### PR TITLE
Keep reqwest client alive

### DIFF
--- a/examples/firefish_authorization.rs
+++ b/examples/firefish_authorization.rs
@@ -10,7 +10,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Firefish, url.to_string(), None, None);
+    let client = generator(megalodon::SNS::Firefish, url.to_string(), None, None).unwrap();
     let options = megalodon::megalodon::AppInputOptions {
         ..Default::default()
     };

--- a/examples/firefish_credentials.rs
+++ b/examples/firefish_credentials.rs
@@ -26,7 +26,7 @@ async fn verify_credentials(
     url: &str,
     access_token: String,
 ) -> Result<entities::Account, error::Error> {
-    let client = generator(SNS::Firefish, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Firefish, url.to_string(), Some(access_token), None)?;
     let res = client.verify_account_credentials().await?;
     Ok(res.json())
 }

--- a/examples/firefish_custom_emojis.rs
+++ b/examples/firefish_custom_emojis.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn emojis(url: &str) -> Result<Vec<entities::Emoji>, error::Error> {
-    let client = generator(SNS::Firefish, url.to_string(), None, None);
+    let client = generator(SNS::Firefish, url.to_string(), None, None)?;
     let res = client.get_instance_custom_emojis().await?;
     Ok(res.json())
 }

--- a/examples/firefish_favourite.rs
+++ b/examples/firefish_favourite.rs
@@ -40,7 +40,7 @@ async fn favourite_status(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.favourite_status(status_id).await?;
 
     Ok(res.json())

--- a/examples/firefish_home.rs
+++ b/examples/firefish_home.rs
@@ -35,7 +35,7 @@ async fn home_timeline(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_home_timeline(None).await?;
 
     Ok(res.json())

--- a/examples/firefish_instance.rs
+++ b/examples/firefish_instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn instance(url: &str) -> Result<entities::Instance, error::Error> {
-    let client = generator(SNS::Firefish, url.to_string(), None, None);
+    let client = generator(SNS::Firefish, url.to_string(), None, None)?;
     let res = client.get_instance().await?;
     Ok(res.json())
 }

--- a/examples/firefish_media.rs
+++ b/examples/firefish_media.rs
@@ -36,7 +36,7 @@ async fn upload_media(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.upload_media(file_path, None).await?;
     Ok(res.json())
 }

--- a/examples/firefish_notifications.rs
+++ b/examples/firefish_notifications.rs
@@ -35,7 +35,7 @@ async fn get_notifications(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_notifications(None).await?;
     Ok(res.json())
 }

--- a/examples/firefish_post_with_media.rs
+++ b/examples/firefish_post_with_media.rs
@@ -18,7 +18,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Firefish, url, Some(token), None);
+    let client = generator(megalodon::SNS::Firefish, url, Some(token), None).unwrap();
 
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path.to_string()).await else {

--- a/examples/firefish_search.rs
+++ b/examples/firefish_search.rs
@@ -32,7 +32,7 @@ async fn search(url: &str, access_token: String) -> Result<entities::Results, er
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.search(String::from("h3poteto"), None).await?;
 
     Ok(res.json())

--- a/examples/firefish_streaming.rs
+++ b/examples/firefish_streaming.rs
@@ -24,7 +24,8 @@ async fn streaming(url: &str, access_token: String) {
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )
+    .unwrap();
     let streaming = client.local_streaming().await;
 
     streaming

--- a/examples/friendica_authorization.rs
+++ b/examples/friendica_authorization.rs
@@ -10,7 +10,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Friendica, url, None, None);
+    let client = generator(megalodon::SNS::Friendica, url, None, None).unwrap();
     let options = megalodon::megalodon::AppInputOptions {
         scopes: Some(
             [

--- a/examples/friendica_credentials.rs
+++ b/examples/friendica_credentials.rs
@@ -26,7 +26,7 @@ async fn verify_credentials(
     url: &str,
     access_token: String,
 ) -> Result<entities::Account, error::Error> {
-    let client = generator(SNS::Friendica, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Friendica, url.to_string(), Some(access_token), None)?;
     let res = client.verify_account_credentials().await?;
     Ok(res.json())
 }

--- a/examples/friendica_favourite.rs
+++ b/examples/friendica_favourite.rs
@@ -40,7 +40,7 @@ async fn favourite_status(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.favourite_status(status_id).await?;
 
     Ok(res.json())

--- a/examples/friendica_follow_requests.rs
+++ b/examples/friendica_follow_requests.rs
@@ -39,7 +39,7 @@ async fn follow_requests(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_follow_requests(None).await?;
 
     Ok(res.json())

--- a/examples/friendica_home.rs
+++ b/examples/friendica_home.rs
@@ -35,7 +35,7 @@ async fn home_timeline(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_home_timeline(None).await?;
 
     Ok(res.json())

--- a/examples/friendica_instance.rs
+++ b/examples/friendica_instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn instance(url: &str) -> Result<entities::Instance, error::Error> {
-    let client = generator(SNS::Friendica, url.to_string(), None, None);
+    let client = generator(SNS::Friendica, url.to_string(), None, None)?;
     let res = client.get_instance().await?;
     Ok(res.json())
 }

--- a/examples/friendica_marker.rs
+++ b/examples/friendica_marker.rs
@@ -49,7 +49,7 @@ async fn save_marker(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client
         .save_markers(Some(&megalodon::megalodon::SaveMarkersInputOptions {
             home: None,
@@ -68,7 +68,7 @@ async fn get_markers(url: &str, access_token: String) -> Result<entities::Marker
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client
         .get_markers(vec![String::from("home"), String::from("notifications")])
         .await?;

--- a/examples/friendica_media.rs
+++ b/examples/friendica_media.rs
@@ -36,7 +36,7 @@ async fn upload_media(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.upload_media(file_path, None).await?;
     Ok(res.json())
 }

--- a/examples/friendica_post_with_media.rs
+++ b/examples/friendica_post_with_media.rs
@@ -18,7 +18,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Friendica, url, Some(token), None);
+    let client = generator(megalodon::SNS::Friendica, url, Some(token), None).unwrap();
 
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path.to_string()).await else {

--- a/examples/friendica_post_with_schedule.rs
+++ b/examples/friendica_post_with_schedule.rs
@@ -16,7 +16,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Friendica, url, Some(token), None);
+    let client = generator(megalodon::SNS::Friendica, url, Some(token), None).unwrap();
 
     let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);

--- a/examples/friendica_reblog.rs
+++ b/examples/friendica_reblog.rs
@@ -40,7 +40,7 @@ async fn reblog_status(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.reblog_status(status_id).await?;
 
     Ok(res.json())

--- a/examples/friendica_relationship.rs
+++ b/examples/friendica_relationship.rs
@@ -35,7 +35,7 @@ async fn get_relationship(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_relationships([id.to_string()].to_vec()).await?;
     Ok(res.json())
 }

--- a/examples/gotosocial_authorization.rs
+++ b/examples/gotosocial_authorization.rs
@@ -9,7 +9,7 @@ async fn main() {
         println!("Specify GOTOSOCIAL_URL!!");
         return;
     };
-    let client = generator(megalodon::SNS::Gotosocial, url, None, None);
+    let client = generator(megalodon::SNS::Gotosocial, url, None, None).unwrap();
     let options = megalodon::megalodon::AppInputOptions {
         scopes: Some(
             [

--- a/examples/gotosocial_credentials.rs
+++ b/examples/gotosocial_credentials.rs
@@ -26,7 +26,7 @@ async fn verify_credentials(
     url: &str,
     access_token: String,
 ) -> Result<entities::Account, error::Error> {
-    let client = generator(SNS::Gotosocial, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Gotosocial, url.to_string(), Some(access_token), None)?;
     let res = client.verify_account_credentials().await?;
     Ok(res.json())
 }

--- a/examples/gotosocial_home.rs
+++ b/examples/gotosocial_home.rs
@@ -35,7 +35,7 @@ async fn home_timeline(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_home_timeline(None).await?;
 
     Ok(res.json())

--- a/examples/gotosocial_instance.rs
+++ b/examples/gotosocial_instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn instance(url: &str) -> Result<entities::Instance, error::Error> {
-    let client = generator(SNS::Gotosocial, url.to_string(), None, None);
+    let client = generator(SNS::Gotosocial, url.to_string(), None, None)?;
     let res = client.get_instance().await?;
     Ok(res.json())
 }

--- a/examples/gotosocial_post.rs
+++ b/examples/gotosocial_post.rs
@@ -14,7 +14,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Gotosocial, url, Some(token), None);
+    let client = generator(megalodon::SNS::Gotosocial, url, Some(token), None).unwrap();
 
     let res = post_status(&client).await;
     match res {

--- a/examples/gotosocial_streaming.rs
+++ b/examples/gotosocial_streaming.rs
@@ -18,7 +18,7 @@ async fn main() {
 }
 
 async fn streaming(url: &str, access_token: String) {
-    let client = generator(SNS::Gotosocial, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Gotosocial, url.to_string(), Some(access_token), None).unwrap();
     let streaming = client.local_streaming().await;
 
     streaming

--- a/examples/mastodon_authorization.rs
+++ b/examples/mastodon_authorization.rs
@@ -9,7 +9,7 @@ async fn main() {
         println!("Specify MASTODON_URL!!");
         return;
     };
-    let client = generator(megalodon::SNS::Mastodon, url, None, None);
+    let client = generator(megalodon::SNS::Mastodon, url, None, None).unwrap();
     let options = megalodon::megalodon::AppInputOptions {
         scopes: Some(
             [

--- a/examples/mastodon_credentials.rs
+++ b/examples/mastodon_credentials.rs
@@ -26,7 +26,7 @@ async fn verify_credentials(
     url: &str,
     access_token: String,
 ) -> Result<entities::Account, error::Error> {
-    let client = generator(SNS::Mastodon, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Mastodon, url.to_string(), Some(access_token), None)?;
     let res = client.verify_account_credentials().await?;
     Ok(res.json())
 }

--- a/examples/mastodon_instance.rs
+++ b/examples/mastodon_instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn instance(url: &str) -> Result<entities::Instance, error::Error> {
-    let client = generator(SNS::Mastodon, url.to_string(), None, None);
+    let client = generator(SNS::Mastodon, url.to_string(), None, None)?;
     let res = client.get_instance().await?;
     Ok(res.json())
 }

--- a/examples/mastodon_marker.rs
+++ b/examples/mastodon_marker.rs
@@ -31,7 +31,7 @@ async fn get_markers(url: &str, access_token: String) -> Result<entities::Marker
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client
         .get_markers(vec![String::from("home"), String::from("notifications")])
         .await?;

--- a/examples/mastodon_media.rs
+++ b/examples/mastodon_media.rs
@@ -36,7 +36,7 @@ async fn upload_media(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.upload_media(file_path, None).await?;
     Ok(res.json())
 }

--- a/examples/mastodon_post_with_media.rs
+++ b/examples/mastodon_post_with_media.rs
@@ -18,7 +18,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Mastodon, url, Some(token), None);
+    let client = generator(megalodon::SNS::Mastodon, url, Some(token), None).unwrap();
 
     let file_path = "./sample.jpg".to_string();
     let Ok(res) = upload_media(&client, file_path.to_string()).await else {

--- a/examples/mastodon_post_with_schedule.rs
+++ b/examples/mastodon_post_with_schedule.rs
@@ -16,7 +16,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Mastodon, url, Some(token), None);
+    let client = generator(megalodon::SNS::Mastodon, url, Some(token), None).unwrap();
 
     let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);

--- a/examples/mastodon_relationship.rs
+++ b/examples/mastodon_relationship.rs
@@ -35,7 +35,7 @@ async fn get_relationship(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_relationships([id.to_string()].to_vec()).await?;
     Ok(res.json())
 }

--- a/examples/mastodon_search.rs
+++ b/examples/mastodon_search.rs
@@ -39,7 +39,7 @@ async fn search(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let options = SearchInputOptions {
         r#type: Some(SearchType::Accounts),
         limit: None,

--- a/examples/mastodon_streaming.rs
+++ b/examples/mastodon_streaming.rs
@@ -23,7 +23,8 @@ async fn streaming(url: &str, access_token: String) {
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )
+    .unwrap();
     let streaming = client.local_streaming().await;
 
     streaming

--- a/examples/mastodon_unauthorized_local.rs
+++ b/examples/mastodon_unauthorized_local.rs
@@ -14,7 +14,7 @@ async fn main() {
 }
 
 async fn streaming(url: &str) {
-    let client = generator(megalodon::SNS::Mastodon, url.to_string(), None, None);
+    let client = generator(megalodon::SNS::Mastodon, url.to_string(), None, None).unwrap();
     let streaming = client.local_streaming().await;
 
     streaming

--- a/examples/mastodon_update_credentials.rs
+++ b/examples/mastodon_update_credentials.rs
@@ -14,7 +14,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(SNS::Mastodon, url, Some(token), None);
+    let client = generator(SNS::Mastodon, url, Some(token), None).unwrap();
 
     let update_creds = megalodon::megalodon::UpdateCredentialsInputOptions {
         fields_attributes: Some(vec![megalodon::megalodon::CredentialsFieldAttribute {

--- a/examples/pleroma_authorization.rs
+++ b/examples/pleroma_authorization.rs
@@ -10,7 +10,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Pleroma, url, None, None);
+    let client = generator(megalodon::SNS::Pleroma, url, None, None).unwrap();
     let options = megalodon::megalodon::AppInputOptions {
         scopes: Some(
             [

--- a/examples/pleroma_conversations.rs
+++ b/examples/pleroma_conversations.rs
@@ -34,7 +34,7 @@ async fn get_conversations(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_conversation_timeline(None).await?;
     Ok(res.json())
 }

--- a/examples/pleroma_credentials.rs
+++ b/examples/pleroma_credentials.rs
@@ -28,7 +28,7 @@ async fn verify_credentials(
     url: &str,
     access_token: String,
 ) -> Result<entities::Account, error::Error> {
-    let client = generator(SNS::Pleroma, url.to_string(), Some(access_token), None);
+    let client = generator(SNS::Pleroma, url.to_string(), Some(access_token), None)?;
     let res = client.verify_account_credentials().await?;
     Ok(res.json())
 }

--- a/examples/pleroma_delete_status.rs
+++ b/examples/pleroma_delete_status.rs
@@ -14,7 +14,7 @@ async fn main() {
         println!("Specify PLEROMA_ACCESS_TOKEN!!");
         return;
     };
-    let client = generator(megalodon::SNS::Pleroma, url.to_string(), Some(token), None);
+    let client = generator(megalodon::SNS::Pleroma, url.to_string(), Some(token), None).unwrap();
     println!("Target status_id: ");
     let mut status_id = String::new();
     std::io::stdin().read_line(&mut status_id).ok();

--- a/examples/pleroma_instance.rs
+++ b/examples/pleroma_instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 }
 
 async fn instance(url: &str) -> Result<entities::Instance, error::Error> {
-    let client = generator(SNS::Pleroma, url.to_string(), None, None);
+    let client = generator(SNS::Pleroma, url.to_string(), None, None)?;
     let res = client.get_instance().await?;
     Ok(res.json())
 }

--- a/examples/pleroma_marker.rs
+++ b/examples/pleroma_marker.rs
@@ -31,7 +31,7 @@ async fn get_markers(url: &str, access_token: String) -> Result<entities::Marker
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client
         .get_markers(vec![String::from("notifications")])
         .await?;

--- a/examples/pleroma_notifications.rs
+++ b/examples/pleroma_notifications.rs
@@ -34,7 +34,7 @@ async fn get_notifications(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_notifications(None).await?;
     Ok(res.json())
 }

--- a/examples/pleroma_post_with_media.rs
+++ b/examples/pleroma_post_with_media.rs
@@ -72,7 +72,7 @@ async fn upload_media(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.upload_media(file_path, None).await?;
     Ok(res.json())
 }
@@ -88,7 +88,7 @@ async fn post_status(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client
         .post_status(
             status.to_string(),

--- a/examples/pleroma_post_with_schedule.rs
+++ b/examples/pleroma_post_with_schedule.rs
@@ -16,7 +16,7 @@ async fn main() {
         return;
     };
 
-    let client = generator(megalodon::SNS::Pleroma, url, Some(token), None);
+    let client = generator(megalodon::SNS::Pleroma, url, Some(token), None).unwrap();
 
     let scheduled_at = Utc::now() + Duration::try_minutes(6).unwrap();
     println!("scheduled at {:#?}", scheduled_at);

--- a/examples/pleroma_relationship.rs
+++ b/examples/pleroma_relationship.rs
@@ -35,7 +35,7 @@ async fn get_relationship(
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )?;
     let res = client.get_relationships([id.to_string()].to_vec()).await?;
     Ok(res.json())
 }

--- a/examples/pleroma_streaming.rs
+++ b/examples/pleroma_streaming.rs
@@ -23,7 +23,8 @@ async fn streaming(url: &str, access_token: String) {
         url.to_string(),
         Some(access_token),
         None,
-    );
+    )
+    .unwrap();
     let streaming = client.user_streaming().await;
 
     streaming

--- a/src/firefish/api_client.rs
+++ b/src/firefish/api_client.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 pub struct APIClient {
     access_token: Option<String>,
     base_url: String,
-    user_agent: String,
+    client: reqwest::Client,
 }
 
 impl APIClient {
@@ -23,10 +23,15 @@ impl APIClient {
             None => ua = DEFAULT_UA.to_string(),
         }
 
+        let client = reqwest::Client::builder()
+            .user_agent(ua)
+            .build()
+            .expect("Failed to initialise TLS backend!");
+
         Self {
             access_token,
             base_url,
-            user_agent: ua,
+            client,
         }
     }
 
@@ -40,11 +45,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.get(url);
+        let mut req = self.client.get(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -100,11 +102,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -153,11 +152,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }

--- a/src/firefish/api_client.rs
+++ b/src/firefish/api_client.rs
@@ -16,23 +16,24 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
         let ua: String;
         match user_agent {
             Some(agent) => ua = agent,
             None => ua = DEFAULT_UA.to_string(),
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(ua)
-            .build()
-            .expect("Failed to initialise TLS backend!");
+        let client = reqwest::Client::builder().user_agent(ua).build()?;
 
-        Self {
+        Ok(Self {
             access_token,
             base_url,
             client,
-        }
+        })
     }
 
     pub async fn get<T>(

--- a/src/firefish/firefish.rs
+++ b/src/firefish/firefish.rs
@@ -38,14 +38,14 @@ impl Firefish {
         base_url: String,
         access_token: Option<String>,
         user_agent: Option<String>,
-    ) -> Firefish {
-        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone());
-        Firefish {
+    ) -> Result<Firefish, Error> {
+        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone())?;
+        Ok(Firefish {
             client,
             base_url,
             access_token,
             user_agent,
-        }
+        })
     }
 
     async fn generate_auth_url_and_token(

--- a/src/friendica/api_client.rs
+++ b/src/friendica/api_client.rs
@@ -16,23 +16,24 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
         let ua: String;
         match user_agent {
             Some(agent) => ua = agent,
             None => ua = DEFAULT_UA.to_string(),
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(ua)
-            .build()
-            .expect("Failed to initialise TLS backend!");
+        let client = reqwest::Client::builder().user_agent(ua).build()?;
 
-        Self {
+        Ok(Self {
             access_token,
             base_url,
             client,
-        }
+        })
     }
 
     pub async fn get<T>(

--- a/src/friendica/api_client.rs
+++ b/src/friendica/api_client.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 pub struct APIClient {
     access_token: Option<String>,
     base_url: String,
-    user_agent: String,
+    client: reqwest::Client,
 }
 
 impl APIClient {
@@ -23,10 +23,15 @@ impl APIClient {
             None => ua = DEFAULT_UA.to_string(),
         }
 
+        let client = reqwest::Client::builder()
+            .user_agent(ua)
+            .build()
+            .expect("Failed to initialise TLS backend!");
+
         Self {
             access_token,
             base_url,
-            user_agent: ua,
+            client,
         }
     }
 
@@ -40,11 +45,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.get(url);
+        let mut req = self.client.get(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -100,11 +102,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -153,11 +152,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -206,11 +202,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -259,11 +252,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -312,11 +302,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.delete(url);
+        let mut req = self.client.delete(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }

--- a/src/friendica/friendica.rs
+++ b/src/friendica/friendica.rs
@@ -35,9 +35,9 @@ impl Friendica {
         base_url: String,
         access_token: Option<String>,
         user_agent: Option<String>,
-    ) -> Friendica {
-        let client = APIClient::new(base_url.clone(), access_token, user_agent);
-        Friendica { client, base_url }
+    ) -> Result<Friendica, Error> {
+        let client = APIClient::new(base_url.clone(), access_token, user_agent)?;
+        Ok(Friendica { client, base_url })
     }
 
     async fn generate_auth_url(

--- a/src/gotosocial/api_client.rs
+++ b/src/gotosocial/api_client.rs
@@ -16,23 +16,24 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
         let ua: String;
         match user_agent {
             Some(agent) => ua = agent,
             None => ua = DEFAULT_UA.to_string(),
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(ua)
-            .build()
-            .expect("Failed to initialise TLS backend!");
+        let client = reqwest::Client::builder().user_agent(ua).build()?;
 
-        Self {
+        Ok(Self {
             access_token,
             base_url,
             client,
-        }
+        })
     }
 
     pub async fn get<T>(

--- a/src/gotosocial/api_client.rs
+++ b/src/gotosocial/api_client.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 pub struct APIClient {
     access_token: Option<String>,
     base_url: String,
-    user_agent: String,
+    client: reqwest::Client,
 }
 
 impl APIClient {
@@ -23,10 +23,15 @@ impl APIClient {
             None => ua = DEFAULT_UA.to_string(),
         }
 
+        let client = reqwest::Client::builder()
+            .user_agent(ua)
+            .build()
+            .expect("Failed to initialise TLS backend!");
+
         Self {
             access_token,
             base_url,
-            user_agent: ua,
+            client,
         }
     }
 
@@ -40,11 +45,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.get(url);
+        let mut req = self.client.get(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -100,11 +102,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -153,11 +152,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -206,11 +202,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -259,11 +252,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -312,11 +302,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.patch(url);
+        let mut req = self.client.patch(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -365,11 +352,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.delete(url);
+        let mut req = self.client.delete(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }

--- a/src/gotosocial/gotosocial.rs
+++ b/src/gotosocial/gotosocial.rs
@@ -37,14 +37,14 @@ impl Gotosocial {
         base_url: String,
         access_token: Option<String>,
         user_agent: Option<String>,
-    ) -> Gotosocial {
-        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone());
-        Gotosocial {
+    ) -> Result<Gotosocial, Error> {
+        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone())?;
+        Ok(Gotosocial {
             client,
             base_url,
             access_token,
             user_agent,
-        }
+        })
     }
 
     async fn generate_auth_url(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!   String::from("https://fedibird.com"),
 //!   None,
 //!   None,
-//! );
+//! )?;
 //! let res = client.get_instance().await?;
 //! println!("{:#?}", res.json());
 //! # Ok(())
@@ -36,7 +36,7 @@
 //!   String::from("https://fedibird.com"),
 //!   Some(String::from("your access token")),
 //!   None,
-//! );
+//! )?;
 //! let res = client.verify_account_credentials().await?;
 //! println!("{:#?}", res.json());
 //! # Ok(())
@@ -60,6 +60,7 @@ pub mod response;
 pub mod streaming;
 
 pub use self::megalodon::Megalodon;
+use crate::error::Error;
 pub use detector::detector;
 use serde::{Deserialize, Serialize};
 pub use streaming::Streaming;
@@ -112,27 +113,27 @@ pub fn generator(
     base_url: String,
     access_token: Option<String>,
     user_agent: Option<String>,
-) -> Box<dyn Megalodon + Send + Sync> {
+) -> Result<Box<dyn Megalodon + Send + Sync>, Error> {
     match sns {
         SNS::Pleroma => {
-            let pleroma = pleroma::Pleroma::new(base_url, access_token, user_agent);
-            Box::new(pleroma)
+            let pleroma = pleroma::Pleroma::new(base_url, access_token, user_agent)?;
+            Ok(Box::new(pleroma))
         }
         SNS::Friendica => {
-            let friendica = friendica::Friendica::new(base_url, access_token, user_agent);
-            Box::new(friendica)
+            let friendica = friendica::Friendica::new(base_url, access_token, user_agent)?;
+            Ok(Box::new(friendica))
         }
         SNS::Mastodon => {
-            let mastodon = mastodon::Mastodon::new(base_url, access_token, user_agent);
-            Box::new(mastodon)
+            let mastodon = mastodon::Mastodon::new(base_url, access_token, user_agent)?;
+            Ok(Box::new(mastodon))
         }
         SNS::Firefish => {
-            let firefish = firefish::Firefish::new(base_url, access_token, user_agent);
-            Box::new(firefish)
+            let firefish = firefish::Firefish::new(base_url, access_token, user_agent)?;
+            Ok(Box::new(firefish))
         }
         SNS::Gotosocial => {
-            let gotosocial = gotosocial::Gotosocial::new(base_url, access_token, user_agent);
-            Box::new(gotosocial)
+            let gotosocial = gotosocial::Gotosocial::new(base_url, access_token, user_agent)?;
+            Ok(Box::new(gotosocial))
         }
     }
 }

--- a/src/mastodon/api_client.rs
+++ b/src/mastodon/api_client.rs
@@ -16,23 +16,24 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
         let ua: String;
         match user_agent {
             Some(agent) => ua = agent,
             None => ua = DEFAULT_UA.to_string(),
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(ua)
-            .build()
-            .expect("Failed to initialise TLS backend!");
+        let client = reqwest::Client::builder().user_agent(ua).build()?;
 
-        Self {
+        Ok(Self {
             access_token,
             base_url,
             client,
-        }
+        })
     }
 
     pub async fn get<T>(

--- a/src/mastodon/api_client.rs
+++ b/src/mastodon/api_client.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 pub struct APIClient {
     access_token: Option<String>,
     base_url: String,
-    user_agent: String,
+    client: reqwest::Client,
 }
 
 impl APIClient {
@@ -23,10 +23,15 @@ impl APIClient {
             None => ua = DEFAULT_UA.to_string(),
         }
 
+        let client = reqwest::Client::builder()
+            .user_agent(ua)
+            .build()
+            .expect("Failed to initialise TLS backend!");
+
         Self {
             access_token,
             base_url,
-            user_agent: ua,
+            client,
         }
     }
 
@@ -40,11 +45,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.get(url);
+        let mut req = self.client.get(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -100,11 +102,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -153,11 +152,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -206,11 +202,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -259,11 +252,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -312,11 +302,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.patch(url);
+        let mut req = self.client.patch(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -365,11 +352,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.delete(url);
+        let mut req = self.client.delete(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }

--- a/src/mastodon/mastodon.rs
+++ b/src/mastodon/mastodon.rs
@@ -37,14 +37,14 @@ impl Mastodon {
         base_url: String,
         access_token: Option<String>,
         user_agent: Option<String>,
-    ) -> Mastodon {
-        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone());
-        Mastodon {
+    ) -> Result<Mastodon, Error> {
+        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone())?;
+        Ok(Mastodon {
             client,
             base_url,
             access_token,
             user_agent,
-        }
+        })
     }
 
     async fn generate_auth_url(

--- a/src/pleroma/api_client.rs
+++ b/src/pleroma/api_client.rs
@@ -16,23 +16,24 @@ pub struct APIClient {
 }
 
 impl APIClient {
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
         let ua: String;
         match user_agent {
             Some(agent) => ua = agent,
             None => ua = DEFAULT_UA.to_string(),
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(ua)
-            .build()
-            .expect("Failed to initialise TLS backend!");
+        let client = reqwest::Client::builder().user_agent(ua).build()?;
 
-        Self {
+        Ok(Self {
             access_token,
             base_url,
             client,
-        }
+        })
     }
 
     pub async fn get<T>(

--- a/src/pleroma/api_client.rs
+++ b/src/pleroma/api_client.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 pub struct APIClient {
     access_token: Option<String>,
     base_url: String,
-    user_agent: String,
+    client: reqwest::Client,
 }
 
 impl APIClient {
@@ -23,10 +23,15 @@ impl APIClient {
             None => ua = DEFAULT_UA.to_string(),
         }
 
+        let client = reqwest::Client::builder()
+            .user_agent(ua)
+            .build()
+            .expect("Failed to initialise TLS backend!");
+
         Self {
             access_token,
             base_url,
-            user_agent: ua,
+            client,
         }
     }
 
@@ -40,11 +45,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.get(url);
+        let mut req = self.client.get(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -93,11 +95,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -146,11 +145,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.post(url);
+        let mut req = self.client.post(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -199,11 +195,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -252,11 +245,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.put(url);
+        let mut req = self.client.put(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -305,11 +295,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.patch(url);
+        let mut req = self.client.patch(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }
@@ -358,11 +345,8 @@ impl APIClient {
     {
         let url_str = format!("{}{}", self.base_url, path);
         let url = Url::parse(&*url_str)?;
-        let client = reqwest::Client::builder()
-            .user_agent(&self.user_agent)
-            .build()?;
 
-        let mut req = client.delete(url);
+        let mut req = self.client.delete(url);
         if let Some(token) = &self.access_token {
             req = req.bearer_auth(token);
         }

--- a/src/pleroma/pleroma.rs
+++ b/src/pleroma/pleroma.rs
@@ -2,6 +2,7 @@ use super::api_client::APIClient;
 use super::entities;
 use super::oauth;
 use super::web_socket::WebSocket;
+use crate::error::Error as MegalodonError;
 use crate::megalodon::FollowRequestOutput;
 use crate::{
     default, entities as MegalodonEntities, error::Error, megalodon, oauth as MegalodonOAuth,
@@ -33,14 +34,18 @@ pub struct Pleroma {
 
 impl Pleroma {
     /// Create a new [`Pleroma`].
-    pub fn new(base_url: String, access_token: Option<String>, user_agent: Option<String>) -> Self {
-        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone());
-        Self {
+    pub fn new(
+        base_url: String,
+        access_token: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self, MegalodonError> {
+        let client = APIClient::new(base_url.clone(), access_token.clone(), user_agent.clone())?;
+        Ok(Self {
             client,
             base_url,
             access_token,
             user_agent,
-        }
+        })
     }
 
     async fn generate_auth_url(


### PR DESCRIPTION
Reuse the `reqwest::Client` between API calls. See #256.

It's possible for `APIClient::new` to panic if `reqwest` fails to initialise the TLS backend. `APIClient::new` could be updated to return a `Result`, although this would mean a breaking change to the API.