### PR TITLE
Fix auth example syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let client = megalodon::generator(
   String::from("https://fedibird.com"),
   Some(String::from("your access token")),
   None,
-);
+)?;
 let res = client.verify_account_credentials().await?;
 println!("{:#?}", res.json());
 ```


### PR DESCRIPTION
`client` is a `Result<_>` so needs to be unwrapped before using `verify_account_credentials`