### PR TITLE
Put standard upper bounds on dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,28 +26,28 @@ rustls-tls = [
 
 [dependencies]
 async-trait = "0.1.80"
-chrono = { version = ">=0.4.38", features = ["serde"] }
-futures-util = ">=0.3.30"
-hex = { version = "0.4" }
+chrono = { version = "0.4.38", features = ["serde"] }
+futures-util = "0.3.30"
+hex = "0.4"
 mime_guess = "2.0"
 oauth2 = "5.0"
 rand = "0.8"
-regex = ">=1.10.4"
-reqwest = { version = ">=0.12.3", features = [
+regex = "1.10.4"
+reqwest = { version = "0.12.3", features = [
     "json",
     "multipart",
     "stream",
 ], default-features = false }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
-sha1 = { version = "0.10" }
-thiserror = ">=1.0.58"
-tokio = { version = ">=1.37.0", features = ["full"] }
+sha1 = "0.10"
+thiserror = "2.0.12"
+tokio = { version = "1.37.0", features = ["full"] }
 tokio-tungstenite = { version = "0.27", features = ["url"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = "0.1.40"
 url = "2.5.0"
-urlencoding = { version = "2.1" }
+urlencoding = "2.1"
 uuid = { version = "1.8", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Some current dependency specifications are unbounded in terms of the maximum version. This doesn't really make sense as e.g. regex version `2.0.0` could contain arbitrary breaking changes that this crate won't compile with.

Leaving off the `>=` does not result in _exact_ version requirements like it would for NPM, rather it's the equivalent of NPM's and other package managers `^1.2.3` syntax (which is also available in Cargo, it's just that you can leave off the `^` and still have it mean the same thing).

For more details, see <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio>.